### PR TITLE
Getting author name from `from` and `project`

### DIFF
--- a/dephell/commands/generate_license.py
+++ b/dephell/commands/generate_license.py
@@ -43,21 +43,30 @@ class GenerateLicenseCommand(BaseCommand):
             self.logger.error('cannot find license with given name')
             return False
 
+        # author name from --owner
+        author = self.config.get('owner')
+
         # get author from `from`
-        loader = CONVERTERS[self.config['from']['format']]
-        root = loader.load(self.config['from']['path'])
-        from_author = None
-        if root.authors:
-            from_author = root.authors
+        if not author and 'from' in self.config:
+            loader = CONVERTERS[self.config['from']['format']]
+            root = loader.load(self.config['from']['path'])
+            if root.authors:
+                author = root.authors
 
         # author from project config file
-        project_author = PackageRoot(self.config['project']).metainfo.authors
+        if not author:
+            authors = PackageRoot(self.config['project']).metainfo.authors
+            if authors:
+                author = authors[0]
+
+        # author from getuser().title
+        if not author:
+            author = getuser().title()
 
         # generate license text
         text = license.make_text(copyright='{year} {name}'.format(
             year=datetime.now().year,
-            name=self.config.get('owner') or getuser().title()
-                                                    or from_author or project_author,
+            name=author,
         ))
         (Path(self.config['project']) / 'LICENSE').write_text(text)
         self.logger.info('license generated', extra=dict(license=license.name))

--- a/dephell/commands/generate_license.py
+++ b/dephell/commands/generate_license.py
@@ -55,7 +55,7 @@ class GenerateLicenseCommand(BaseCommand):
 
         # author from project config file
         if not author:
-            authors = PackageRoot(self.config['project']).metainfo.authors
+            authors = PackageRoot(Path(self.config['project'])).metainfo.authors
             if authors:
                 author = authors[0]
 

--- a/dephell/commands/generate_license.py
+++ b/dephell/commands/generate_license.py
@@ -51,7 +51,7 @@ class GenerateLicenseCommand(BaseCommand):
             loader = CONVERTERS[self.config['from']['format']]
             root = loader.load(self.config['from']['path'])
             if root.authors:
-                author = root.authors
+                author = root.authors[0]
 
         # author from project config file
         if not author:

--- a/dephell/commands/generate_license.py
+++ b/dephell/commands/generate_license.py
@@ -55,9 +55,9 @@ class GenerateLicenseCommand(BaseCommand):
 
         # author from project config file
         if not author:
-            authors = PackageRoot(Path(self.config['project'])).metainfo.authors
-            if authors:
-                author = authors[0]
+            metainfo = PackageRoot(Path(self.config['project'])).metainfo
+            if metainfo and metainfo.authors:
+                author = metainfo.authors[0]
 
         # author from getuser().title
         if not author:


### PR DESCRIPTION
Fix for issue #107 - getting the author name in `generate license` from `from` and `project` config files.

Please do review this and suggest changes as there may be errors. Thanks!