### PR TITLE
authors: Set text encoding to utf-8

### DIFF
--- a/dephell/commands/generate_authors.py
+++ b/dephell/commands/generate_authors.py
@@ -37,6 +37,6 @@ class GenerateAuthorsCommand(BaseCommand):
             name = name.strip().replace('"', '')
             authors[mail] = name
         lines = ('{} <{}>'.format(name, mail) for mail, name in authors.items())
-        Path('AUTHORS').write_text('\n'.join(sorted(lines)), encoding="utf-8")
+        Path('AUTHORS').write_text('\n'.join(sorted(lines)), encoding='utf-8')
         self.logger.info('AUTHORS generated')
         return True

--- a/dephell/commands/generate_authors.py
+++ b/dephell/commands/generate_authors.py
@@ -37,6 +37,6 @@ class GenerateAuthorsCommand(BaseCommand):
             name = name.strip().replace('"', '')
             authors[mail] = name
         lines = ('{} <{}>'.format(name, mail) for mail, name in authors.items())
-        Path('AUTHORS').write_text('\n'.join(sorted(lines)))
+        Path('AUTHORS').write_text('\n'.join(sorted(lines)), encoding="utf-8")
         self.logger.info('AUTHORS generated')
         return True


### PR DESCRIPTION
On Windows 10 the `dephell generate authors` command was failing due to an encoding error.

This error occurred when the git log had non Windows-1252 characters in the authors field.
Which is the case in the pypa sampleproject used in the README tutorial.

close #124