### PR TITLE
bash-completion: use modern lazy-load directory

### DIFF
--- a/dephell/commands/autocomplete.py
+++ b/dephell/commands/autocomplete.py
@@ -2,6 +2,7 @@
 from argparse import ArgumentParser
 from pathlib import Path
 from platform import platform
+import os
 
 # external
 from appdirs import user_data_dir
@@ -49,22 +50,29 @@ class AutocompleteCommand(BaseCommand):
     def _bash(self):
         script = make_bash_autocomplete()
 
-        # https://github.com/dephell/dephell/pull/62
-        path = Path.home() / '.local' / 'etc' / 'bash_completion.d' / 'dephell.bash-completion'
-        if platform().lower() == 'darwin':
-            # ref. https://itnext.io/programmable-completion-for-bash-on-macos-f81a0103080b
-            path = Path('/') / 'usr' / 'local' / 'etc' / 'bash_completion.d' / 'dephell.bash-completion'
+        # Install completions to the correct location for modern bash-completion.
+        # This will be sourced on-demand by bash-completion as soon as dephell is
+        # completed for the first time.
+        if 'BASH_COMPLETION_USER_DIR' in os.environ:
+            bashcomp_user_dir = Path(os.environ.get('BASH_COMPLETION_USER_DIR'))
+        else:
+            bashcomp_user_dir = Path(os.getenv('XDG_DATA_HOME', '~/.local/share')).expanduser() / 'bash-completion'
+        path = bashcomp_user_dir / 'completions' / 'dephell'
+
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(script)
 
-        for rc_name in ('.bashrc', '.profile', '.bash_profile'):
-            rc_path = Path.home() / rc_name
-            if not rc_path.exists():
-                continue
-            if 'bash_completion.d' not in rc_path.read_text():
-                with rc_path.open('a') as stream:
-                    stream.write('\n\nsource "{}"\n'.format(str(path)))
-            break
+        # We cannot reliably assume bash-completion 2.x exists on macOS,
+        # so inject it into the user's bashrc
+        if platform().lower() == 'darwin':
+            for rc_name in ('.bashrc', '.profile', '.bash_profile'):
+                rc_path = Path.home() / rc_name
+                if not rc_path.exists():
+                    continue
+                if 'completions/dephell' not in rc_path.read_text():
+                    with rc_path.open('a') as stream:
+                        stream.write('\n\nsource "{}"\n'.format(str(path)))
+                break
 
     def _zsh(self):
         script = make_zsh_autocomplete()


### PR DESCRIPTION
The legacy bash_completion.d directory requires every script be sourced at shell startup, which is slow. Since bash-completion 2.x (released in 2012), completions are loaded on-demand -- a minimal completion stub is defined as the default command completer, which will search for a script in the completionsdir named the same as the command, and source this script in order to update the command completion.

Make use of this lazy-loaded completion. This entails:
- moving the installation location
- getting rid of the legacy modification of .bashrc which is no longer needed