### PR TITLE
Change `--tag` option from bool to template in project:bump command

### DIFF
--- a/dephell/actions/_git.py
+++ b/dephell/actions/_git.py
@@ -2,28 +2,27 @@
 import subprocess
 from logging import getLogger
 from pathlib import Path
-from typing import Iterable
-
+from typing import Iterable, Tuple
 
 logger = getLogger('dephell.actions.git')
 
 
-def _run(command, project: Path) -> bool:
+def _run(command, project: Path) -> Tuple[bool, str]:
     result = subprocess.run(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=str(project),
     )
+    stdout = result.stdout.decode().strip()
     if result.returncode != 0:
         stderr = result.stderr.decode().strip()
         if stderr:
             logger.debug(stderr)
-        stdout = result.stdout.decode().strip()
         if stdout:
             logger.debug(stdout)
-        return False
-    return True
+        return False, stderr
+    return True, stdout
 
 
 def git_commit(message: str, paths: Iterable[Path], project: Path) -> bool:
@@ -31,8 +30,10 @@ def git_commit(message: str, paths: Iterable[Path], project: Path) -> bool:
         ok = _run(['git', 'add', '--update', str(path)], project=project)
         if not ok:
             return False
-    return _run(['git', 'commit', '-m', message], project=project)
+    result, _ = _run(['git', 'commit', '-m', message], project=project)
+    return result
 
 
 def git_tag(name: str, project: Path) -> bool:
-    return _run(['git', 'tag', name], project=project)
+    result, _ = _run(['git', 'tag', name], project=project)
+    return result

--- a/dephell/commands/project_bump.py
+++ b/dephell/commands/project_bump.py
@@ -149,7 +149,7 @@ class ProjectBumpCommand(BaseCommand):
             tag_name = '{prefix}{version}'.format(prefix=tag_prefix_or_template, version=new_version)
         project = Path(self.config['project'])
         if not (project / '.git').exists():
-            self.logger.error('project doesn\'t contains .git in root folder, cannot create git tag')
+            self.logger.error("project doesn\'t contains .git in root folder, cannot create git tag")
             return
 
         self.logger.info('commit and tag')

--- a/dephell/commands/project_bump.py
+++ b/dephell/commands/project_bump.py
@@ -95,10 +95,11 @@ class ProjectBumpCommand(BaseCommand):
             paths.append(Path(self.config['from']['path']))
 
         # set git tag
-        if self.config.get('tag'):
-            self._add_git_tag(paths=paths, new_version=new_version, tag_prefix_or_template=self.config['tag'])
+        tagged = True
+        if self.config.get('tag') is not None:
+            tagged = self._add_git_tag(paths=paths, new_version=new_version, tag_prefix_or_template=self.config['tag'])
 
-        return True
+        return tagged
 
     @staticmethod
     def _bump_project(project: PackageRoot, old: str, new: str) -> Iterator[Path]:
@@ -138,7 +139,7 @@ class ProjectBumpCommand(BaseCommand):
             stream.write(new_content)
         return True
 
-    def _add_git_tag(self, paths, new_version, tag_prefix_or_template):
+    def _add_git_tag(self, paths, new_version, tag_prefix_or_template: str) -> bool:
         if '{version}' in tag_prefix_or_template:
             # if used template with `{version}` placeholder
             # for example: `--tag=v.{version}` will be transform to `v.3.0.1`
@@ -150,7 +151,7 @@ class ProjectBumpCommand(BaseCommand):
         project = Path(self.config['project'])
         if not (project / '.git').exists():
             self.logger.error("project doesn\'t contains .git in root folder, cannot create git tag")
-            return
+            return False
 
         self.logger.info('commit and tag')
         ok = git_commit(
@@ -170,3 +171,5 @@ class ProjectBumpCommand(BaseCommand):
             return False
 
         self.logger.info('tag created, do not forget to push it: git push --tags')
+
+        return True

--- a/dephell/config/scheme.py
+++ b/dephell/config/scheme.py
@@ -79,7 +79,7 @@ SCHEME = {
 
     # other
     'owner':    dict(type='string', required=False),
-    'tag':      dict(type='boolean', required=False),
+    'tag':      dict(type='string', required=False, regex='{new_version}'),
     'cache':    dict(
         type='dict',
         required=True,

--- a/dephell/config/scheme.py
+++ b/dephell/config/scheme.py
@@ -79,7 +79,7 @@ SCHEME = {
 
     # other
     'owner':    dict(type='string', required=False),
-    'tag':      dict(type='string', required=False, regex='.*{new_version}.*'),
+    'tag':      dict(type='string', required=False),
     'cache':    dict(
         type='dict',
         required=True,

--- a/dephell/config/scheme.py
+++ b/dephell/config/scheme.py
@@ -79,7 +79,7 @@ SCHEME = {
 
     # other
     'owner':    dict(type='string', required=False),
-    'tag':      dict(type='string', required=False, regex='{new_version}'),
+    'tag':      dict(type='string', required=False, regex='.*{new_version}.*'),
     'cache':    dict(
         type='dict',
         required=True,

--- a/docs/cmd-project-bump.md
+++ b/docs/cmd-project-bump.md
@@ -24,7 +24,7 @@ Command steps:
 1. Write new version in `from` file.
 
 Also, the command adds git tag if `--tag` option (or `tag = <your_template>` in the config) is specified as template.
- Template can be string with `{version}` placeholder (e.g. `v.{version}`) or just prefix string (e.g. `v.`)
+Template can be string with `{version}` placeholder (e.g. `v.{version}`) or just prefix string (e.g. `v.`)
 
 ```bash
 $ dephell project bump --tag=v.

--- a/docs/cmd-project-bump.md
+++ b/docs/cmd-project-bump.md
@@ -23,11 +23,11 @@ Command steps:
 1. Write new version in source code. DepHell looks for `__version__` variable in project source and writes new version in it.
 1. Write new version in `from` file.
 
-Also, the command adds git tag if `--tag` option (or `tag = <your_template>` in the config) is specified as template 
-with `{new_version}` placeholder:
+Also, the command adds git tag if `--tag` option (or `tag = <your_template>` in the config) is specified as template.
+ Template can be string with `{version}` placeholder (e.g. `v.{version}`) or just prefix string (e.g. `v.`)
 
 ```bash
-$ dephell project bump --tag 'v.{new_version}'
+$ dephell project bump --tag=v.
 INFO generated new version (old=0.8.0, new=0.9.0)
 INFO file bumped (path=/home/gram/Documents/dephell/dephell/__init__.py)
 INFO commit and tag

--- a/docs/cmd-project-bump.md
+++ b/docs/cmd-project-bump.md
@@ -27,7 +27,7 @@ Also, the command adds git tag if `--tag` option (or `tag = <your_template>` in 
 Template can be string with `{version}` placeholder (e.g. `v.{version}`) or just prefix string (e.g. `v.`)
 
 ```bash
-$ dephell project bump --tag=v.
+$ dephell project bump --tag=v. minor
 INFO generated new version (old=0.8.0, new=0.9.0)
 INFO file bumped (path=/home/gram/Documents/dephell/dephell/__init__.py)
 INFO commit and tag

--- a/docs/cmd-project-bump.md
+++ b/docs/cmd-project-bump.md
@@ -23,10 +23,11 @@ Command steps:
 1. Write new version in source code. DepHell looks for `__version__` variable in project source and writes new version in it.
 1. Write new version in `from` file.
 
-Also, the command adds git tag if `--tag` option (or `tag = True` in the config) is specified:
+Also, the command adds git tag if `--tag` option (or `tag = <your_template>` in the config) is specified as template 
+with `{new_version}` placeholder:
 
 ```bash
-$ dephell project bump --tag minor
+$ dephell project bump --tag 'v.{new_version}'
 INFO generated new version (old=0.8.0, new=0.9.0)
 INFO file bumped (path=/home/gram/Documents/dephell/dephell/__init__.py)
 INFO commit and tag

--- a/tests/test_commands/test_project_bump.py
+++ b/tests/test_commands/test_project_bump.py
@@ -1,21 +1,59 @@
 # built-in
 from pathlib import Path
 
+# third-party
+import pytest
 
 # project
 from dephell.commands import ProjectBumpCommand
 from dephell.config import Config
+from dephell.actions._git import _run
 
 
 def test_bump_command(temp_path: Path):
-    (temp_path / 'project').mkdir()
-    init_path = (temp_path / 'project' / '__init__.py')
+    project_path = (temp_path / 'project')
+    project_path.mkdir()
+    init_path = (project_path / '__init__.py')
     init_path.write_text('__version__ = "1.2.3"')
     config = Config()
     config.attach({
-        'project': str(temp_path),
+        'project': str(project_path),
     })
     command = ProjectBumpCommand(argv=['fix'], config=config)
     result = command()
     assert result is True
     assert init_path.read_text() == '__version__ = "1.2.4"'
+
+
+@pytest.mark.parametrize(
+    'tag_template,expected_tag', [
+        ('prefix.', 'prefix.1.2.4'),
+        ('with.{version}.placeholder', 'with.1.2.4.placeholder'),
+        ('', '1.2.4'),
+        ('{version}', '1.2.4')
+    ]
+)
+def test_bump_command_with_placeholder_tag(temp_path: Path, tag_template, expected_tag):
+    project_path = (temp_path / 'project')
+    project_path.mkdir()
+    init_path = (project_path / '__init__.py')
+    init_path.write_text('__version__ = "1.2.3"')
+    config = Config()
+    config.attach({
+        'project': str(project_path),
+        'tag': tag_template,
+    })
+    # init local repo and add `__init__.py` to git index
+    _run(['git', 'init'], project=project_path)
+
+    # it's needed because bump command with tag generates not only tag, but also commit with --update flag
+    # --update add to commit only modified files, not created (__init__.py in this case is created)
+    _run(["git", "add", "."], project=project_path)
+
+    command = ProjectBumpCommand(argv=['fix'], config=config)
+    result = command()
+    assert result is True
+
+    # just read stdout from git tag command
+    _, tags = _run(["git", "tag"], project=project_path)
+    assert tags == expected_tag

--- a/tests/test_commands/test_project_bump.py
+++ b/tests/test_commands/test_project_bump.py
@@ -29,7 +29,7 @@ def test_bump_command(temp_path: Path):
     ('prefix.', 'prefix.1.2.4'),
     ('with.{version}.placeholder', 'with.1.2.4.placeholder'),
     ('', '1.2.4'),
-    ('{version}', '1.2.4')
+    ('{version}', '1.2.4'),
 ])
 def test_bump_command_with_placeholder_tag(temp_path: Path, tag_template, expected_tag):
     project_path = (temp_path / 'project')
@@ -46,12 +46,12 @@ def test_bump_command_with_placeholder_tag(temp_path: Path, tag_template, expect
 
     # it's needed because bump command with tag generates not only tag, but also commit with --update flag
     # --update add to commit only modified files, not created (__init__.py in this case is created)
-    _run(["git", "add", "."], project=project_path)
+    _run(['git', 'add', '.'], project=project_path)
 
     command = ProjectBumpCommand(argv=['fix'], config=config)
     result = command()
     assert result is True
 
     # just read stdout from git tag command
-    _, tags = _run(["git", "tag"], project=project_path)
+    _, tags = _run(['git', 'tag'], project=project_path)
     assert tags == expected_tag

--- a/tests/test_commands/test_project_bump.py
+++ b/tests/test_commands/test_project_bump.py
@@ -25,14 +25,12 @@ def test_bump_command(temp_path: Path):
     assert init_path.read_text() == '__version__ = "1.2.4"'
 
 
-@pytest.mark.parametrize(
-    'tag_template,expected_tag', [
-        ('prefix.', 'prefix.1.2.4'),
-        ('with.{version}.placeholder', 'with.1.2.4.placeholder'),
-        ('', '1.2.4'),
-        ('{version}', '1.2.4')
-    ]
-)
+@pytest.mark.parametrize('tag_template, expected_tag', [
+    ('prefix.', 'prefix.1.2.4'),
+    ('with.{version}.placeholder', 'with.1.2.4.placeholder'),
+    ('', '1.2.4'),
+    ('{version}', '1.2.4')
+])
 def test_bump_command_with_placeholder_tag(temp_path: Path, tag_template, expected_tag):
     project_path = (temp_path / 'project')
     project_path.mkdir()


### PR DESCRIPTION
Closes #197 

I have questions about three things:
1. CONTRIBUTE.md doesn't say anything about running modified dephell for manual testing, only running checking and testing. Now I'm using `poetry run dephell` command, but I'm not sure about it.
2. I don't see any tests for argument schema validation. Why?
2. I have no idea about git tag creation testing :( I tried to search, but found only tests for git package resolving.