### PR TITLE
Fix no traceback and CLI options parsing

### DIFF
--- a/dephell/cli.py
+++ b/dephell/cli.py
@@ -65,6 +65,8 @@ def main(argv: List[str]) -> int:
         return ReturnCodes.INVALID_CONFIG.value
     except Exception as e:
         logger.exception('{}: {}'.format(type(e).__name__, e))
+        if '--traceback' in argv:
+            raise
         return ReturnCodes.UNKNOWN_EXCEPTION.value
 
     # validate config

--- a/dephell/config/manager.py
+++ b/dephell/config/manager.py
@@ -126,6 +126,9 @@ class Config:
             if len(parsed) == 1:
                 data[name] = value
             else:
+                # if old content isn't a dict, override it
+                if not isinstance(data[parsed[0]], dict):
+                    data[parsed[0]] = dict()
                 data[parsed[0]][parsed[1]] = value
         self.attach(data)
         return dict(data)


### PR DESCRIPTION
1. Show traceback for an unknown exception in the config parser
1. Override conflicting options

Close #190 