### PR TITLE
DeepSource

### DIFF
--- a/dephell/actions/_entrypoints.py
+++ b/dephell/actions/_entrypoints.py
@@ -1,6 +1,6 @@
 # built-in
 from logging import getLogger
-from typing import Tuple
+from typing import Tuple, Optional
 
 # external
 from dephell_venvs import VEnv
@@ -13,18 +13,18 @@ from ..models import EntryPoint
 logger = getLogger('dephell.actions')
 
 
-def get_entrypoints(*, venv: VEnv, name: str) -> Tuple[EntryPoint, ...]:
+def get_entrypoints(*, venv: VEnv, name: str) -> Optional[Tuple[EntryPoint, ...]]:
     if not venv.lib_path:
         logger.critical('cannot locate lib path in the venv')
-        return False
+        return None
     paths = list(venv.lib_path.glob('{}*.*-info'.format(name)))
     if not paths:
         paths = list(venv.lib_path.glob('{}*.*-info'.format(name.replace('-', '_'))))
         if not paths:
             logger.critical('cannot locate dist-info for installed package')
-            return False
+            return None
     path = paths[0] / 'entry_points.txt'
     if not path.exists():
         logger.error('cannot find any entrypoints for package')
-        return False
+        return None
     return EggInfoConverter().parse_entrypoints(content=path.read_text()).entrypoints

--- a/dephell/actions/_json.py
+++ b/dephell/actions/_json.py
@@ -19,7 +19,7 @@ def _each(value):
     return new_value
 
 
-def _flatten(value):
+def _flatten(value) -> list:
     if not isinstance(value, (list, tuple)):
         return [value]
     new_value = []
@@ -33,24 +33,24 @@ FILTERS = {
     'first()': lambda v: v[0],
     'flatten()': _flatten,
     'last()': lambda v: v[-1],
-    'len()': lambda v: len(v),
-    'max()': lambda v: max(v),
-    'min()': lambda v: min(v),
+    'len()': len,
+    'max()': max,
+    'min()': min,
     'reverse()': lambda v: v[::-1],
-    'sort()': lambda v: sorted(v),
-    'sum()': lambda v: sum(v),
+    'sort()': sorted,
+    'sum()': sum,
     'type()': lambda v: type(v).__name__,
     'zip()': lambda v: list(map(list, zip(*v))),
 
     # aliases
     '#': _each,
-    'count()': lambda v: len(v),
+    'count()': len,
     'flat()': _flatten,
     'latest()': lambda v: v[-1],
-    'length()': lambda v: len(v),
+    'length()': len,
     'reversed()': lambda v: v[::-1],
-    'size()': lambda v: len(v),
-    'sorted()': lambda v: sorted(v),
+    'size()': len,
+    'sorted()': sorted,
 }
 
 

--- a/dephell/converters/base.py
+++ b/dephell/converters/base.py
@@ -78,4 +78,4 @@ class BaseConverter:
         extra, marker = text.split(':')
         if not extra:
             extra = 'main'
-        return extra, None
+        return extra, marker

--- a/dephell/exceptions.py
+++ b/dephell/exceptions.py
@@ -5,6 +5,7 @@ class ExtraException(Exception):
         if message:
             self.message = message
         self.extra = kwargs
+        super().__init__(message, **kwargs)
 
     def __str__(self) -> str:
         return self.message

--- a/dephell/exceptions.py
+++ b/dephell/exceptions.py
@@ -5,7 +5,7 @@ class ExtraException(Exception):
         if message:
             self.message = message
         self.extra = kwargs
-        super().__init__(message, **kwargs)
+        super().__init__(message, kwargs)
 
     def __str__(self) -> str:
         return self.message

--- a/dephell/repositories/_conda/_git.py
+++ b/dephell/repositories/_conda/_git.py
@@ -24,12 +24,6 @@ from ...networking import aiohttp_session
 from ._base import CondaBaseRepo
 
 
-try:
-    import yaml as pyyaml
-except ImportError:
-    pyyaml = None
-
-
 # source: conda-build/metadata.py
 # Selectors must be either:
 # - at end of the line

--- a/dephell/repositories/_warehouse/_local.py
+++ b/dephell/repositories/_warehouse/_local.py
@@ -39,10 +39,10 @@ class WarehouseLocalRepo(WarehouseBaseRepo):
     def get_releases(self, dep) -> tuple:
 
         releases_info = dict()
-        for path in self.path.glob('**/*'):
-            if not path.name.endswith(ARCHIVE_EXTENSIONS):
+        for archive_path in self.path.glob('**/*'):
+            if not archive_path.name.endswith(ARCHIVE_EXTENSIONS):
                 continue
-            name, version = self._parse_name(path.name)
+            name, version = self._parse_name(archive_path.name)
             if canonicalize_name(name) != dep.name:
                 continue
             if not version:
@@ -50,7 +50,7 @@ class WarehouseLocalRepo(WarehouseBaseRepo):
 
             if version not in releases_info:
                 releases_info[version] = []
-            releases_info[version].append(self._get_hash(path=path))
+            releases_info[version].append(self._get_hash(path=archive_path))
 
         # init releases
         releases = []
@@ -60,7 +60,7 @@ class WarehouseLocalRepo(WarehouseBaseRepo):
             release = Release(
                 raw_name=dep.raw_name,
                 version=version,
-                time=datetime.fromtimestamp(path.stat().st_mtime),
+                time=datetime.fromtimestamp(self.path.stat().st_mtime),
                 hashes=hashes,
                 extra=dep.extra,
             )


### PR DESCRIPTION
@mohi7solanki from @deepsourcelabs team has run DeepSource on DepHell:
https://deepsource.io/gh/mohi7solanki/dephell/issues/

Some issues aren't really important, some of them are strange, but some of them valuable and potentially dangerous. This PR fixes these bugs.

Things that I've treated as unimportant:
1. Disabled escaping in Jinja2 when making console output, because after that HTML is processed into Markdown.
1. Used debugger. It's a feature to make possible do post-mortem by `--pdb` flag.
1. Redefinition of `license` variable. I've never used this built-in variable and totally ok with shadowing it.
1. False-positive on `def get_releases(self, dep)`. That can't be replaced by a property because accepts an argument.
1. Catching too general `Exception` on formatting CLI output and ignoring exceptions from cursed external processes.
1. Fake credentials in tests
