### PR TITLE
`path` support for poetry and pip specifiers

### DIFF
--- a/dephell/commands/base.py
+++ b/dephell/commands/base.py
@@ -119,10 +119,7 @@ class BaseCommand:
             path=loader_config['path'],
         ))
         loader = CONVERTERS[loader_config['format']]
-        loader = loader.copy(
-            project_path=Path(self.config['project']),
-            resolve_path=Path(loader_config['path']).parent,
-        )
+        loader = loader.copy(project_path=Path(self.config['project']))
         resolver = loader.load_resolver(path=loader_config['path'])
         attach_deps(resolver=resolver, config=self.config, merge=False)
         return self._resolve(resolver=resolver, default_envs=default_envs)

--- a/dephell/commands/deps_add.py
+++ b/dephell/commands/deps_add.py
@@ -36,10 +36,7 @@ class DepsAddCommand(BaseCommand):
             self.error('`--from` is required for this command')
             return False
         converter = CONVERTERS[self.config['from']['format']]
-        converter = converter.copy(
-            project_path=Path(self.config['project']),
-            resolve_path=Path(self.config['from']['path']).parent,
-        )
+        converter = converter.copy(project_path=Path(self.config['project']))
         resolver = converter.load_resolver(path=self.config['from']['path'])
 
         # get new deps

--- a/dephell/commands/deps_convert.py
+++ b/dephell/commands/deps_convert.py
@@ -34,15 +34,9 @@ class DepsConvertCommand(BaseCommand):
             self.error('`--to` is required for this command')
             return False
         loader = CONVERTERS[self.config['from']['format']]
-        loader = loader.copy(
-            project_path=Path(self.config['project']),
-            resolve_path=Path(self.config['from']['path']).parent,
-        )
+        loader = loader.copy(project_path=Path(self.config['project']))
         dumper = CONVERTERS[self.config['to']['format']]
-        dumper = dumper.copy(
-            project_path=Path(self.config['project']),
-            resolve_path=Path(self.config['to']['path']).parent,
-        )
+        dumper = dumper.copy(project_path=Path(self.config['project']))
 
         # load
         self.logger.debug('load dependencies...', extra=dict(

--- a/dephell/commands/generate_license.py
+++ b/dephell/commands/generate_license.py
@@ -45,10 +45,7 @@ class GenerateLicenseCommand(BaseCommand):
         # get author from `from`
         if not author and 'from' in self.config:
             loader = CONVERTERS[self.config['from']['format']]
-            loader = loader.copy(
-                project_path=Path(self.config['project']),
-                resolve_path=Path(self.config['from']['path']).parent,
-            )
+            loader = loader.copy(project_path=Path(self.config['project']))
             root = loader.load(self.config['from']['path'])
             if root.authors:
                 author = root.authors[0]

--- a/dephell/commands/project_build.py
+++ b/dephell/commands/project_build.py
@@ -35,10 +35,7 @@ class ProjectBuildCommand(BaseCommand):
 
     def __call__(self) -> bool:
         loader = CONVERTERS[self.config['from']['format']]
-        loader = loader.copy(
-            project_path=Path(self.config['project']),
-            resolve_path=Path(self.config['from']['path']).parent,
-        )
+        loader = loader.copy(project_path=Path(self.config['project']))
         resolver = loader.load_resolver(path=self.config['from']['path'])
         if loader.lock:
             self.logger.warning('do not build project from lockfile!')
@@ -59,10 +56,7 @@ class ProjectBuildCommand(BaseCommand):
                 continue
             self.logger.info('dumping...', extra=dict(format=to_format))
             dumper = CONVERTERS[to_format]
-            dumper = dumper.copy(
-                project_path=Path(self.config['project']),
-                resolve_path=Path(to_path).parent,
-            )
+            dumper = dumper.copy(project_path=Path(self.config['project']))
             dumper.dump(
                 path=project_path.joinpath(to_path),
                 reqs=reqs,

--- a/dephell/commands/project_bump.py
+++ b/dephell/commands/project_bump.py
@@ -49,10 +49,7 @@ class ProjectBumpCommand(BaseCommand):
         if 'from' in self.config:
             # get project metainfo
             loader = CONVERTERS[self.config['from']['format']]
-            loader = loader.copy(
-                project_path=Path(self.config['project']),
-                resolve_path=Path(self.config['from']['path']).parent,
-            )
+            loader = loader.copy(project_path=Path(self.config['project']))
             root = loader.load(path=self.config['from']['path'])
             if root.version != '0.0.0':
                 package = root.package

--- a/dephell/commands/project_test.py
+++ b/dephell/commands/project_test.py
@@ -36,10 +36,7 @@ class ProjectTestCommand(BaseCommand):
     def __call__(self) -> bool:
         # load project
         loader = CONVERTERS[self.config['from']['format']]
-        loader = loader.copy(
-            project_path=Path(self.config['project']),
-            resolve_path=Path(self.config['from']['path']).parent,
-        )
+        loader = loader.copy(project_path=Path(self.config['project']))
         resolver = loader.load_resolver(path=self.config['from']['path'])
         if loader.lock:
             self.logger.warning('do not build project from lockfile!')

--- a/dephell/controllers/_dependency.py
+++ b/dephell/controllers/_dependency.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import List, Optional, Union
 
 # external
-from dephell_links import VCSLink, parse_link, UnknownLink
+from dephell_links import UnknownLink, VCSLink, parse_link
 from dephell_markers import Markers
 from dephell_specifier import GitSpecifier
 from packaging.requirements import Requirement as PackagingRequirement

--- a/dephell/controllers/_dependency.py
+++ b/dephell/controllers/_dependency.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import List, Optional, Union
 
 # external
-from dephell_links import VCSLink, parse_link
+from dephell_links import VCSLink, parse_link, UnknownLink
 from dephell_markers import Markers
 from dephell_specifier import GitSpecifier
 from packaging.requirements import Requirement as PackagingRequirement
@@ -82,9 +82,13 @@ class DependencyMaker:
                     **kwargs) -> List[Union[Dependency, ExtraDependency]]:
 
         # make link
-        link = parse_link(url)
-        if link and link.name and rex_hash.fullmatch(raw_name):
-            raw_name = link.name
+        if not url or isinstance(url, str):
+            link = parse_link(url)
+        else:
+            link = url
+        if link and not isinstance(link, UnknownLink):
+            if link.name and rex_hash.fullmatch(raw_name):
+                raw_name = link.name
 
         # make constraint
         if isinstance(constraint, str):

--- a/dephell/converters/pip.py
+++ b/dephell/converters/pip.py
@@ -42,6 +42,8 @@ class PIPConverter(BaseConverter):
         if isinstance(path, str):
             path = Path(path)
         path = self._make_source_path_absolute(path)
+        self._resolve_path = path.parent
+
         root = RootDependency(
             package=PackageRoot(path=self.project_path or path.parent),
         )

--- a/dephell/converters/pipfile.py
+++ b/dephell/converters/pipfile.py
@@ -139,8 +139,7 @@ class PIPFileConverter(BaseConverter):
         return tomlkit.dumps(doc).rstrip() + '\n'
 
     # https://github.com/pypa/pipfile/blob/master/examples/Pipfile
-    @staticmethod
-    def _make_deps(root, name: str, content) -> List[Dependency]:
+    def _make_deps(self, root, name: str, content) -> List[Dependency]:
         if isinstance(content, str):
             return [Dependency(
                 raw_name=name,
@@ -149,7 +148,11 @@ class PIPFileConverter(BaseConverter):
             )]
 
         # get link
-        url = content.get('file') or content.get('path') or content.get('vcs')
+        url = content.get('file') or content.get('path')
+        if url:
+            url = str(self._make_dependency_path_absolute(Path(url)))
+        if not url:
+            url = content.get('vcs')
         if not url:
             for vcs in VCS_LIST:
                 if vcs in content:

--- a/dephell/converters/pipfile.py
+++ b/dephell/converters/pipfile.py
@@ -149,7 +149,7 @@ class PIPFileConverter(BaseConverter):
 
         # get link
         url = content.get('file') or content.get('path')
-        if url:
+        if url and not url.startswith('http'):
             url = str(self._make_dependency_path_absolute(Path(url)))
         if not url:
             url = content.get('vcs')

--- a/dephell/converters/poetry.py
+++ b/dephell/converters/poetry.py
@@ -296,8 +296,7 @@ class PoetryConverter(BaseConverter):
             del section['source']
 
     # https://github.com/sdispater/tomlkit/blob/master/pyproject.toml
-    @staticmethod
-    def _make_deps(root, name: str, content, envs: set) -> List[Dependency]:
+    def _make_deps(self, root, name: str, content, envs: set) -> List[Dependency]:
         if isinstance(content, str):
             deps = [Dependency(
                 raw_name=name,
@@ -309,6 +308,8 @@ class PoetryConverter(BaseConverter):
 
         # get link
         url = content.get('file') or content.get('path')
+        if url and not url.startswith('http'):
+            url = str(self._make_dependency_path_absolute(Path(url)))
         if not url and 'git' in content:
             url = 'git+' + content['git']
         rev = content.get('rev') or content.get('branch') or content.get('tag')

--- a/dephell/converters/poetry.py
+++ b/dephell/converters/poetry.py
@@ -346,7 +346,7 @@ class PoetryConverter(BaseConverter):
                 result[name] = value
         if req.prereleases:
             result['allows-prereleases'] = True
-        if 'version' not in result:
+        if 'version' not in result and 'git' not in result:
             result['version'] = '*'
         # if we have only version, return string instead of table
         if tuple(result.value) == ('version', ):

--- a/dephell/converters/setuppy.py
+++ b/dephell/converters/setuppy.py
@@ -76,7 +76,10 @@ class SetupPyConverter(BaseConverter):
         return ('setup(' in content)
 
     def load(self, path) -> RootDependency:
-        path = Path(str(path))
+        if isinstance(path, str):
+            path = Path(path)
+        path = self._make_source_path_absolute(path)
+        self._resolve_path = path.parent
 
         info = self._execute(path=path)
         if info is None:

--- a/dephell/models/requirement.py
+++ b/dephell/models/requirement.py
@@ -2,6 +2,9 @@
 from collections import OrderedDict, defaultdict
 from typing import Iterable, Optional, Set, Tuple
 
+# external
+from dephell_links import DirLink, FileLink
+
 # app
 from ..cached_property import cached_property
 
@@ -9,7 +12,7 @@ from ..cached_property import cached_property
 class Requirement:
     _properties = (
         'name', 'release', 'version', 'extras', 'markers',
-        'hashes', 'sources', 'editable', 'git', 'rev',
+        'hashes', 'sources', 'editable', 'git', 'rev', 'path',
         'description', 'optional', 'platform', 'python',
     )
 
@@ -81,6 +84,12 @@ class Requirement:
     @property
     def git(self) -> Optional[str]:
         if getattr(self.dep.link, 'vcs', '') == 'git':
+            return self.dep.link.short
+        return None  # mypy wants it
+
+    @property
+    def path(self) -> Optional[str]:
+        if isinstance(self.dep.link, (DirLink, FileLink)):
             return self.dep.link.short
         return None  # mypy wants it
 

--- a/dephell/repositories/_local.py
+++ b/dephell/repositories/_local.py
@@ -22,7 +22,7 @@ class LocalRepo(Interface):
         releases = []
         dist_path = (self.path / 'dist')
         if dist_path.exists():
-            repo = WarehouseLocalRepo(path=dist_path)
+            repo = WarehouseLocalRepo(name='tmp', path=dist_path)
             releases = list(repo.get_releases(dep=dep))
 
         root = self.get_root(name=dep.name, version='0.0.0')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def temp_cache(temp_path):
 
 
 @pytest.fixture
-def requirements_dir() -> Path:
+def requirements_path() -> Path:
     """ Return the absolute Path to 'tests/requirements' """
     return Path(__file__).parent / Path('requirements')
 

--- a/tests/requirements/pipfile.toml
+++ b/tests/requirements/pipfile.toml
@@ -14,7 +14,10 @@ records = '>0.5.0'
 django = { git = 'https://github.com/django/django.git', ref = '1.11.4', editable = true }
 "e682b37" = {file = "https://github.com/divio/django-cms/archive/release/3.4.x.zip"}
 "e1839a8" = {path = ".", editable = true}
-pywinusb = { version = "*", os_name = "=='nt'", index="pypi"}
+pywinusb = { version = "*", os_name = '=="nt"', index="pypi"}
+
+egg-info = {path = "./egg-info/"}
+setup = {path = "./setup.py"}
 
 [dev-packages]
 nose = '*'

--- a/tests/requirements/poetry.toml
+++ b/tests/requirements/poetry.toml
@@ -34,6 +34,10 @@ pendulum = { version = "^1.4", optional = true }
 psycopg2 = { version = "^2.7", optional = true }
 mysqlclient = { version = "^1.3", optional = true }
 
+# local dependency
+egg-info = { path = "./egg-info/" }
+setup = { path = "./setup.py" }
+
 [tool.poetry.extras]
 mysql = ["mysqlclient"]
 pgsql = ["psycopg2"]

--- a/tests/test_commands/test_build.py
+++ b/tests/test_commands/test_build.py
@@ -1,5 +1,4 @@
 # built-in
-import shutil
 from pathlib import Path
 
 # project
@@ -7,12 +6,11 @@ from dephell.commands import ProjectBuildCommand
 from dephell.config import Config
 
 
-def test_build_command(temp_path: Path):
+def test_build_command(requirements_path, temp_path: Path):
     (temp_path / 'project').mkdir()
     (temp_path / 'project' / '__init__.py').touch()
 
-    metainfo_path = str(temp_path / 'pyproject.toml')
-    shutil.copy(str(Path('tests') / 'requirements' / 'poetry.toml'), metainfo_path)
+    metainfo_path = str(requirements_path / 'poetry.toml')
     config = Config()
     config.attach({
         'from': dict(format='poetry', path=metainfo_path),

--- a/tests/test_commands/test_deps_convert.py
+++ b/tests/test_commands/test_deps_convert.py
@@ -7,10 +7,10 @@ from dephell.commands import DepsConvertCommand
 from dephell.config import Config
 
 
-def test_convert_poetry_to_setup(temp_path: Path, requirements_dir: Path):
+def test_convert_poetry_to_setup(temp_path: Path, requirements_path: Path):
     from_path = str(temp_path / 'pyproject.toml')
     to_path = temp_path / 'setup.py'
-    shutil.copy(str(requirements_dir / 'poetry.toml'), from_path)
+    shutil.copy(str(requirements_path / 'poetry.toml'), from_path)
     config = Config()
     config.attach({
         'from': dict(format='poetry', path=from_path),
@@ -25,9 +25,9 @@ def test_convert_poetry_to_setup(temp_path: Path, requirements_dir: Path):
     assert 'The description of the package' in content
 
 
-def test_convert_to_stdout(temp_path: Path, requirements_dir: Path, capsys):
+def test_convert_to_stdout(temp_path: Path, requirements_path: Path, capsys):
     from_path = str(temp_path / 'pyproject.toml')
-    shutil.copy(str(requirements_dir / 'poetry.toml'), from_path)
+    shutil.copy(str(requirements_path / 'poetry.toml'), from_path)
     config = Config()
     config.attach({
         'from': {'format': 'poetry', 'path': from_path},

--- a/tests/test_commands/test_deps_convert.py
+++ b/tests/test_commands/test_deps_convert.py
@@ -1,5 +1,4 @@
 # built-in
-import shutil
 from pathlib import Path
 
 # project
@@ -8,9 +7,8 @@ from dephell.config import Config
 
 
 def test_convert_poetry_to_setup(temp_path: Path, requirements_path: Path):
-    from_path = str(temp_path / 'pyproject.toml')
+    from_path = str(requirements_path / 'poetry.toml')
     to_path = temp_path / 'setup.py'
-    shutil.copy(str(requirements_path / 'poetry.toml'), from_path)
     config = Config()
     config.attach({
         'from': dict(format='poetry', path=from_path),
@@ -26,8 +24,7 @@ def test_convert_poetry_to_setup(temp_path: Path, requirements_path: Path):
 
 
 def test_convert_to_stdout(temp_path: Path, requirements_path: Path, capsys):
-    from_path = str(temp_path / 'pyproject.toml')
-    shutil.copy(str(requirements_path / 'poetry.toml'), from_path)
+    from_path = str(requirements_path / 'poetry.toml')
     config = Config()
     config.attach({
         'from': {'format': 'poetry', 'path': from_path},

--- a/tests/test_commands/test_package_downloads.py
+++ b/tests/test_commands/test_package_downloads.py
@@ -9,7 +9,7 @@ from dephell.commands import PackageDownloadsCommand
 from dephell.config import Config
 
 
-@pytest.mark.skipif(True)  # disable while pypistat is down
+@pytest.mark.skipif(True, 'disable while pypistat is down')
 @pytest.mark.allow_hosts()
 def test_package_downloads_command(capsys):
     config = Config()

--- a/tests/test_commands/test_package_downloads.py
+++ b/tests/test_commands/test_package_downloads.py
@@ -9,7 +9,7 @@ from dephell.commands import PackageDownloadsCommand
 from dephell.config import Config
 
 
-@pytest.mark.skipif(True, 'disable while pypistat is down')
+@pytest.mark.skipif(True, reason='disable while pypistat is down')
 @pytest.mark.allow_hosts()
 def test_package_downloads_command(capsys):
     config = Config()

--- a/tests/test_commands/test_package_downloads.py
+++ b/tests/test_commands/test_package_downloads.py
@@ -9,6 +9,7 @@ from dephell.commands import PackageDownloadsCommand
 from dephell.config import Config
 
 
+@pytest.mark.skipif(True)  # disable while pypistat is down
 @pytest.mark.allow_hosts()
 def test_package_downloads_command(capsys):
     config = Config()

--- a/tests/test_commands/test_vendor_download.py
+++ b/tests/test_commands/test_vendor_download.py
@@ -8,14 +8,14 @@ from dephell.controllers import DependencyMaker
 from dephell.models import RootDependency
 
 
-def test_extract_modules(temp_path: Path, requirements_dir: Path):
+def test_extract_modules(temp_path: Path, requirements_path: Path):
     config = Config()
     config.attach(dict(project=str(temp_path)))
     command = VendorDownloadCommand(argv=[], config=config)
     dep = DependencyMaker.from_requirement(source=RootDependency(), req='dephell')[0]
     result = command._extract_modules(
         dep=dep,
-        archive_path=requirements_dir / 'wheel.whl',
+        archive_path=requirements_path / 'wheel.whl',
         output_path=temp_path,
     )
     assert result is True

--- a/tests/test_repositories/test_warehouse_api.py
+++ b/tests/test_repositories/test_warehouse_api.py
@@ -111,13 +111,13 @@ def test_get_deps_auth(asyncio_mock, temp_cache, fixtures_path: Path):
 
 
 def test_download(asyncio_mock, temp_cache, fixtures_path: Path, temp_path: Path,
-                  requirements_dir: Path):
+                  requirements_path: Path):
     pypi_url = 'https://custom.pypi.org/pypi/'
     json_response = (fixtures_path / 'warehouse-api-release.json').read_text()
     json_content = json.loads(json_response)
     file_url = json_content['urls'][0]['url']
     file_name = json_content['urls'][0]['filename']
-    file_content = (requirements_dir / 'wheel.whl').read_bytes()
+    file_content = (requirements_path / 'wheel.whl').read_bytes()
 
     asyncio_mock.get(pypi_url + 'dephell-shells/0.1.2/json', body=json_response)
     asyncio_mock.get(file_url, body=file_content)

--- a/tests/test_repositories/test_warehouse_simple.py
+++ b/tests/test_repositories/test_warehouse_simple.py
@@ -129,7 +129,7 @@ def test_get_deps_auth(requests_mock, temp_cache, fixtures_path):
 
 
 def test_download(requests_mock, asyncio_mock, temp_cache, fixtures_path: Path,
-                  temp_path: Path, requirements_dir: Path):
+                  temp_path: Path, requirements_path: Path):
     pypi_url = 'https://custom.pypi.org/pypi/'
     text_response = (fixtures_path / 'warehouse-simple.html').read_text()
     file_url = re.findall(
@@ -137,7 +137,7 @@ def test_download(requests_mock, asyncio_mock, temp_cache, fixtures_path: Path,
         text_response,
     )[0]
     file_name = urlparse(file_url).path.split('/')[-1]
-    file_content = (requirements_dir / 'wheel.whl').read_bytes()
+    file_content = (requirements_path / 'wheel.whl').read_bytes()
 
     requests_mock.get(pypi_url + 'dephell-shells/', text=text_response)
     asyncio_mock.get(file_url, body=file_content)


### PR DESCRIPTION
1. Close #227
2. Improvement for #229: do not add `version` if `git` is specified.