### PR TITLE
tests: ensure git commit has access to a pseudo identity

### DIFF
--- a/tests/test_commands/test_project_bump.py
+++ b/tests/test_commands/test_project_bump.py
@@ -79,6 +79,8 @@ def test_bump_command_with_placeholder_tag(temp_path: Path, tag_template, expect
     })
     # init local repo and add `__init__.py` to git index
     _run(['git', 'init'], project=project_path)
+    _run(['git', 'config', '--local', 'user.name', 'dephell testsuite'], project=project_path)
+    _run(['git', 'config', '--local', 'user.email', 'test@dephell.invalid.'], project=project_path)
 
     # it's needed because bump command with tag generates not only tag, but also commit with --update flag
     # --update add to commit only modified files, not created (__init__.py in this case is created)


### PR DESCRIPTION
When trying to run the testsuite in a container, the committer ident is more than usually likely to not be configured, in which case the test case aborts due to git commit erroring out.

Fix by adding a dummy identity local to the test repository.