### PR TITLE
Change "ERROR env {name} not found" to something more informative.

### DIFF
--- a/dephell/config/manager.py
+++ b/dephell/config/manager.py
@@ -117,7 +117,7 @@ class Config:
 
         # get env
         if env not in data:
-            raise KeyError('env `{}` not found'.format(env))
+            raise KeyError('env `{}` not found in config'.format(env))
         data = data[env]
 
         self.attach(data)


### PR DESCRIPTION
Close #196