### PR TITLE
setuppy.py: Force version to string

### DIFF
--- a/dephell/converters/setuppy.py
+++ b/dephell/converters/setuppy.py
@@ -286,6 +286,7 @@ class SetupPyConverter(BaseConverter):
             value = getattr(msg, name, None)
         if not value:
             return ''
+        value = str(value)
         if value == 'UNKNOWN':
             return ''
         return value.strip()


### PR DESCRIPTION
When the value is a packaging.specifiers.SpecifierSet,
- comparisons to UNKNOWN fail with Invalid specifier: 'UNKNOWN'.
- invoking value.strip() fails as it has no attribute 'strip'

Related to https://github.com/dephell/dephell/issues/284