### PR TITLE
added inspect project command

### DIFF
--- a/dephell/commands/discover.py
+++ b/dephell/commands/discover.py
@@ -36,6 +36,7 @@ _NAMES = (
     'inspect gadget',
     'inspect self',
     'inspect venv',
+    'inspect project',
 
     'jail install',
     'jail list',

--- a/dephell/commands/inspect_project.py
+++ b/dephell/commands/inspect_project.py
@@ -1,13 +1,15 @@
 # built-in
 from argparse import ArgumentParser
-import attr
 from pathlib import Path
 
+import attr
+
+from ..actions import make_json
+from ..config import builders
 # app
 from ..converters import CONVERTERS
-from ..config import builders
 from .base import BaseCommand
-from ..actions import make_json
+
 
 class InspectProjectCommand(BaseCommand):
     """Inspect the current project.

--- a/dephell/commands/inspect_project.py
+++ b/dephell/commands/inspect_project.py
@@ -2,11 +2,12 @@
 from argparse import ArgumentParser
 from pathlib import Path
 
+# external
 import attr
 
+# app
 from ..actions import make_json
 from ..config import builders
-# app
 from ..converters import CONVERTERS
 from .base import BaseCommand
 

--- a/dephell/commands/inspect_project.py
+++ b/dephell/commands/inspect_project.py
@@ -1,0 +1,45 @@
+# built-in
+from argparse import ArgumentParser
+import attr
+from pathlib import Path
+
+# app
+from ..converters import CONVERTERS
+from ..config import builders
+from .base import BaseCommand
+from ..actions import make_json
+
+class InspectProjectCommand(BaseCommand):
+    """Inspect the current project.
+    """
+    @classmethod
+    def get_parser(cls) -> ArgumentParser:
+        parser = cls._get_default_parser()
+        builders.build_config(parser)
+        builders.build_from(parser)
+        builders.build_output(parser)
+        builders.build_api(parser)
+        builders.build_other(parser)
+        return parser
+
+    def __call__(self) -> bool:
+        if 'from' in self.config:
+            # get project metainfo
+            loader = CONVERTERS[self.config['from']['format']]
+            loader = loader.copy(project_path=Path(self.config['project']))
+            root = loader.load(path=self.config['from']['path'])
+            data = attr.asdict(root)
+
+            result = dict(
+                project_name=data['raw_name'],
+                version=data['version'],
+                description=data['description'],
+            )
+
+            print(make_json(
+                data=result,
+                key=self.config.get('filter'),
+                colors=not self.config['nocolors'],
+                table=self.config['table'],
+            ))
+        return True

--- a/docs/cmd-inspect-project.md
+++ b/docs/cmd-inspect-project.md
@@ -1,0 +1,23 @@
+# dephell inspect project
+
+Shows metainfo from the `from` dependency file, like project name, version, required python, etc.
+
+```bash
+$ dephell inspect project
+{
+  "description": "Dependency resolution for Python",
+  "links": {
+    "documentation": "https://dephell.org/docs/",
+    "homepage": "https://dephell.org/",
+    "repository": "https://github.com/dephell/dephell"
+  },
+  "name": "dephell",
+  "python": ">=3.5",
+  "version": "0.7.8"
+}
+```
+
+## See also
+
+1. [dephell project validate](cmd-project-validate) to check project metadata for compatibility issues and missed information.
+1. [dephell inspect config](cmd-inspect-config) to get information about the project configuration.

--- a/docs/index-inspect.md
+++ b/docs/index-inspect.md
@@ -1,6 +1,6 @@
 # **inspect**: info about environment
 
-Commands to get information about environment: [dephell config](cmd-inspect-config), [dephell ecosystem versions](cmd-inspect-self), [virtual environment](cmd-inspect-venv), [stored credentials](cmd-inspect-auth).
+Commands to get information about environment: [dephell config](cmd-inspect-config), [dephell ecosystem versions](cmd-inspect-self), [project metainfo](cmd-inspect-project), [virtual environment](cmd-inspect-venv), [stored credentials](cmd-inspect-auth).
 
 ```eval_rst
 .. toctree::
@@ -8,6 +8,7 @@ Commands to get information about environment: [dephell config](cmd-inspect-conf
 
     cmd-inspect-auth
     cmd-inspect-config
+    cmd-inspect-project
     cmd-inspect-self
     cmd-inspect-venv
 ```

--- a/tests/test_commands/test_inspect_project.py
+++ b/tests/test_commands/test_inspect_project.py
@@ -1,6 +1,5 @@
 # built-in
 import json
-import sys
 from pathlib import Path
 
 # project
@@ -25,4 +24,4 @@ def test_inspect_project_command(temp_path: Path, requirements_path: Path, capsy
     captured = capsys.readouterr()
     print(captured.out)
     output = json.loads(captured.out)
-    assert output['project_name']=='my-package' 
+    assert output['project_name'] == 'my-package'

--- a/tests/test_commands/test_inspect_project.py
+++ b/tests/test_commands/test_inspect_project.py
@@ -8,10 +8,13 @@ from dephell.commands import InspectProjectCommand
 from dephell.config import Config
 
 
-def test_inspect_project_command(temp_path: Path, capsys):
+def test_inspect_project_command(temp_path: Path, requirements_path: Path, capsys):
+    from_path = str(requirements_path / 'poetry.toml')
     config = Config()
     config.attach({
-        'project': 'nani',
+        'from': {'format': 'poetry', 'path': from_path},
+        'to': {'format': 'setuppy', 'path': 'stdout'},
+        'project': str(temp_path),
         'nocolors': True,
     })
 
@@ -20,5 +23,6 @@ def test_inspect_project_command(temp_path: Path, capsys):
     assert result is True
 
     captured = capsys.readouterr()
+    print(captured.out)
     output = json.loads(captured.out)
-    assert output['project_name']=='nani' 
+    assert output['project_name']=='my-package' 

--- a/tests/test_commands/test_inspect_project.py
+++ b/tests/test_commands/test_inspect_project.py
@@ -12,7 +12,6 @@ def test_inspect_project_command(temp_path: Path, requirements_path: Path, capsy
     config = Config()
     config.attach({
         'from': {'format': 'poetry', 'path': from_path},
-        'to': {'format': 'setuppy', 'path': 'stdout'},
         'project': str(temp_path),
         'nocolors': True,
     })
@@ -24,4 +23,6 @@ def test_inspect_project_command(temp_path: Path, requirements_path: Path, capsy
     captured = capsys.readouterr()
     print(captured.out)
     output = json.loads(captured.out)
-    assert output['project_name'] == 'my-package'
+    assert set(output) == {'name', 'version', 'description', 'links', 'python'}
+    assert output['name'] == 'my-package'
+    assert output['version'] == '0.1.0'

--- a/tests/test_commands/test_inspect_project.py
+++ b/tests/test_commands/test_inspect_project.py
@@ -1,0 +1,24 @@
+# built-in
+import json
+import sys
+from pathlib import Path
+
+# project
+from dephell.commands import InspectProjectCommand
+from dephell.config import Config
+
+
+def test_inspect_project_command(temp_path: Path, capsys):
+    config = Config()
+    config.attach({
+        'project': 'nani',
+        'nocolors': True,
+    })
+
+    command = InspectProjectCommand(argv=[], config=config)
+    result = command()
+    assert result is True
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output['project_name']=='nani' 


### PR DESCRIPTION
Close #90.

The `inspect project` command works locally and gives the following output : 
```
$ python3 -m dephell inspect project
{
  "description": "A sample Python project",
  "raw_name": "sampleproject",
  "version": "1.4.0"
}
```
The JSON, right now has only 3 keys. More can be added if required
I have written a simple test file for `inspect project` which I tested using 
`dephell inspect project --env pytest`. 
More complex tests can be added to the test file if required.

I will proceed with the docs, if this was what is required to achieve.
Please suggest any changes if need be.