### PR TITLE
setuppy: Remove _patched_open

### DIFF
--- a/dephell/converters/setuppy.py
+++ b/dephell/converters/setuppy.py
@@ -1,7 +1,6 @@
 # built-in
 from collections import defaultdict
 from distutils.core import run_setup
-from io import BytesIO, StringIO
 from json import dumps as json_dumps
 from logging import getLogger
 from pathlib import Path
@@ -54,12 +53,6 @@ setup(
     {kwargs},
 )
 """
-
-
-def _patched_open(fname, mode='r', *args, **kwargs):
-    if 'b' in mode:
-        return BytesIO(fname.encode('utf8'))
-    return StringIO(fname)
 
 
 class SetupPyConverter(BaseConverter):
@@ -271,7 +264,6 @@ class SetupPyConverter(BaseConverter):
         globe = {
             '__file__': str(path),
             '__name__': '__main__',
-            'open': _patched_open,
         }
         with chdir(path.parent):
             try:


### PR DESCRIPTION
_patched_open used the filename as the file contents to avoid
loading the file.  This fails when used like exec(open('..'))
as in the case of idna 2.8

Related to https://github.com/dephell/dephell/issues/284