### PR TITLE
setuppy: Add traceback in _execute

### DIFF
--- a/dephell/converters/setuppy.py
+++ b/dephell/converters/setuppy.py
@@ -277,7 +277,7 @@ class SetupPyConverter(BaseConverter):
             try:
                 exec(compile(new_source, path.name, 'exec'), globe)
             except Exception as e:
-                logger.error('{}: {}'.format(type(e).__name__, str(e)))
+                logger.exception('_execute {}: {}'.format(type(e).__name__, str(e)))
 
         dist = globe.get('_dist')
         if dist is None:


### PR DESCRIPTION
When an exception occurs while running the fake setup.py in `_execute`,
the traceback is useful for determining how to improve the logic.