### PR TITLE
setuppy: Allow setup.py to import local modules

### DIFF
--- a/dephell/converters/setuppy.py
+++ b/dephell/converters/setuppy.py
@@ -1,4 +1,5 @@
 # built-in
+import sys
 from collections import defaultdict
 from distutils.core import run_setup
 from json import dumps as json_dumps
@@ -76,10 +77,15 @@ class SetupPyConverter(BaseConverter):
         path = self._make_source_path_absolute(path)
         self._resolve_path = path.parent
 
+        old_sys_path = sys.path
+        sys.path.append(str(path.parent))
+
         info = self._execute(path=path)
         if info is None:
             with chdir(path.parent):
                 info = run_setup(path.name)
+
+        sys.path = old_sys_path
 
         root = RootDependency(
             raw_name=self._get(info, 'name'),

--- a/tests/test_converters/test_setuppy.py
+++ b/tests/test_converters/test_setuppy.py
@@ -77,6 +77,25 @@ def test_run_setup_function(temp_path: Path):
     assert dist.get_name() == 'foo'
 
 
+def test_import(temp_path: Path):
+    with open(str(temp_path / 'local_module.py'), 'w') as f:
+        f.write(dedent("""
+        name = 'imported'
+        """))
+    path = temp_path / 'setup.py'
+    with open(str(path), 'w') as f:
+        f.write(dedent("""
+        import sys
+        print(sys.path)
+        import local_module
+        setup(name=local_module.name)
+        """))
+
+    root = SetupPyConverter().load(path)
+
+    assert root.name == 'imported'
+
+
 def test_dumps_deps():
     path = Path('tests') / 'requirements' / 'setup.py'
     converter = SetupPyConverter()


### PR DESCRIPTION
Add the directory containing setup.py to sys.path
during `_execute` and `run_setup`, so that import of
local modules are successful.  These imports may be
the package to be installed, or other modules
beside setup.py that contain extra logic.

Related to https://github.com/dephell/dephell/issues/284