### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,13 @@ script:
 
 matrix:
   include:
-    - python: "3.5"
-      env: ENV=pytest
     - python: "3.6.7"
       env: ENV=pytest
     - python: "3.7"
       env: ENV=pytest
-    # - python: "3.8-dev"
-    #   env: ENV=pytest
-    - python: "pypy3.5"
+    - python: "3.8"
+      env: ENV=pytest
+    - python: "pypy3.6"
       env: ENV=pytest
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       env: ENV=pytest
     - python: "3.8"
       env: ENV=pytest
-    - python: "pypy3.6"
+    - python: "pypy3"
       env: ENV=pytest
 
     - os: osx

--- a/dephell/actions/_travis.py
+++ b/dephell/actions/_travis.py
@@ -29,15 +29,13 @@ matrix:
 """
 
 PYTEST = """
-    - python: "3.5"
-      env: ENV={env}
     - python: "3.6.7"
       env: ENV={env}
     - python: "3.7"
       env: ENV={env}
-    - python: "3.8-dev"
+    - python: "3.8"
       env: ENV={env}
-    - python: "pypy3.5"
+    - python: "pypy3.6"
       env: ENV={env}
 
     - os: osx

--- a/dephell/commands/jail_install.py
+++ b/dephell/commands/jail_install.py
@@ -94,6 +94,5 @@ class JailInstallCommand(BaseCommand):
         if IS_WINDOWS:
             shutil.copy(str(src), str(dst))
         else:
-            # Python 3.5 cannot resove non-existing paths.
             dst = dst.parent.resolve() / dst.name
             dst.symlink_to(src)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -135,17 +134,15 @@ classifiers = [
 dephell = "dephell.cli:entrypoint"
 
 [tool.poetry.dependencies]
-python = ">=3.5"
+python = ">=3.6"
 aiohttp = "*"
 appdirs = "*"
 attrs = ">=19.2.0"
-bowler = {python = ">=3.6",version = "*"}
-bowler-py35 = {version = ">=0.9.1",python = "<3.6"}
+bowler = "*"
 cerberus = ">=1.3"
 docker = "*"
 dockerpty = "*"
-fissix = {python = ">=3.6",allows-prereleases = true,version = "*"}
-fissix-py35 = {python = "<3.6",version = "*"}
+fissix = {allows-prereleases = true, version = "*"}
 flatdict = "*"
 html5lib = "*"
 jinja2 = "*"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name='dephell',
     version='0.7.9',
     description='Dependency resolution for Python',
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     project_urls={
         "documentation": "https://dephell.org/docs/",
         "homepage": "https://dephell.org/",
@@ -38,7 +38,6 @@ setup(
         'Framework :: Setuptools Plugin', 'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8', 'Topic :: Security',
@@ -55,19 +54,15 @@ setup(
     package_dir={"": "."},
     package_data={"dephell": ["templates/*.j2", "templates/*.sh"]},
     install_requires=[
-        'aiohttp', 'appdirs', 'attrs>=19.2.0',
-        'bowler; python_version >= "3.6"',
-        'bowler-py35>=0.9.1; python_version < "3.6"', 'cerberus>=1.3',
+        'aiohttp', 'appdirs', 'attrs>=19.2.0', 'bowler', 'cerberus>=1.3',
         'dephell-archive>=0.1.5', 'dephell-discover>=0.2.6',
         'dephell-licenses>=0.1.6', 'dephell-links>=0.1.4',
         'dephell-markers>=1.0.0', 'dephell-pythons>=0.1.11',
         'dephell-setuptools>=0.2.1', 'dephell-shells>=0.1.3',
         'dephell-specifier>=0.1.7', 'dephell-venvs>=0.1.16',
-        'dephell-versioning', 'docker', 'dockerpty',
-        'fissix; python_version >= "3.6"',
-        'fissix-py35; python_version < "3.6"', 'flatdict', 'html5lib', 'jinja2',
-        'm2r', 'packaging', 'pip>=18.0', 'pygments', 'requests', 'ruamel.yaml',
-        'setuptools', 'tabulate', 'tomlkit', 'yaspin'
+        'dephell-versioning', 'docker', 'dockerpty', 'fissix', 'flatdict',
+        'html5lib', 'jinja2', 'm2r', 'packaging', 'pip>=18.0', 'pygments',
+        'requests', 'ruamel.yaml', 'setuptools', 'tabulate', 'tomlkit', 'yaspin'
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
As I see in dephell downloads, nobody installs dephell on Python 3.5. So, let's drop support for it.