### PR TITLE
fix dephell self upgrade fail

### DIFF
--- a/dephell/commands/self_upgrade.py
+++ b/dephell/commands/self_upgrade.py
@@ -34,7 +34,7 @@ class SelfUpgradeCommand(BaseCommand):
             return (result.returncode == 0)
 
     def _upgrade_package(self) -> bool:
-        manager = PackageManager(executable=sys.executable)
+        manager = PackageManager(executable=Path(sys.executable))
         args = ['-U']
         if manager.is_global:
             args.append('--user')


### PR DESCRIPTION
Closes #356 
This PR fix issue where dephell self upgrade was failing since executable passed was str instead of Path in dephell/commands/self_upgrade.py file. This PR converts sys.executable str to pathlib.Path so parent attribute can be used.