### PR TITLE
Simplify graph cleaning

### DIFF
--- a/dephell/controllers/_resolver.py
+++ b/dephell/controllers/_resolver.py
@@ -84,8 +84,10 @@ class Resolver:
         with spinner as spinner:
             while True:
                 resolved = self._resolve(debug=debug, silent=silent, level=level, spinner=spinner)
-                if resolved is not None:
-                    return resolved
+                if resolved is None:
+                    continue
+                self.graph.clear()  # remove unused deps from graph
+                return resolved
 
     def _resolve(self, debug: bool, silent: bool, level: Optional[int], spinner) -> Optional[bool]:
         if silent:

--- a/dephell/models/requirement.py
+++ b/dephell/models/requirement.py
@@ -27,8 +27,10 @@ class Requirement:
     def from_graph(cls, graph, *, lock: bool) -> Tuple['Requirement', ...]:
         result = OrderedDict()
         extras = defaultdict(list)
-        applied = graph.applied
         roots = [root.name for root in graph.get_layer(0)]
+
+        # remove unused deps from graph
+        graph.clear()
 
         # if roots wasn't applied then apply them
         if len(graph._layers) == 1:
@@ -39,8 +41,6 @@ class Requirement:
         # get all nodes
         for layer in reversed(graph._layers[1:]):  # skip roots
             for dep in sorted(layer):
-                if applied and not dep.applied:
-                    continue
                 if dep.constraint.empty:
                     continue
                 if dep.extra is None:

--- a/dephell/models/requirement.py
+++ b/dephell/models/requirement.py
@@ -29,9 +29,6 @@ class Requirement:
         extras = defaultdict(list)
         roots = [root.name for root in graph.get_layer(0)]
 
-        # remove unused deps from graph
-        graph.clear()
-
         # if roots wasn't applied then apply them
         if len(graph._layers) == 1:
             for root in graph._roots:


### PR DESCRIPTION
Before converting into requirements we have to remove unused dependencies from the graph. Such deps happen after their ancestors were removed from the graph because of conflict. We keep such dependencies in the graph for state caching but don't want to see them in the resulting graph.

Before this I used some implicit metric: if we applied some dependencies, let's remove unapplied one. Now let's use a more explicit metric: if a dependency wasn't used, we don't need it anymore.

This PR can have an impact because shit happens. However, let's hope our tests are good.