### PR TITLE
Enable test for package downloads

### DIFF
--- a/tests/test_commands/test_package_downloads.py
+++ b/tests/test_commands/test_package_downloads.py
@@ -9,7 +9,6 @@ from dephell.commands import PackageDownloadsCommand
 from dephell.config import Config
 
 
-@pytest.mark.skipif(True, reason='disable while pypistat is down')
 @pytest.mark.allow_hosts()
 def test_package_downloads_command(capsys):
     config = Config()


### PR DESCRIPTION
pypistat is alive again. Re-enable integration tests.