### PR TITLE
fix entrypoint.txt lookup for Sphinx

### DIFF
--- a/dephell/actions/_entrypoints.py
+++ b/dephell/actions/_entrypoints.py
@@ -18,9 +18,12 @@ def get_entrypoints(*, venv: VEnv, name: str) -> Optional[Tuple[EntryPoint, ...]
     if not venv.lib_path:
         logger.critical('cannot locate lib path in the venv')
         return None
-    paths = list(venv.lib_path.glob('{}*.*-info'.format(name)))
+    name_anycase = ''.join([
+        '[{}{}]'.format(x.lower(), x.upper()) if x.isalpha() else x for x in name
+    ])
+    paths = list(venv.lib_path.glob('{}-*.*-info'.format(name_anycase)))
     if not paths:
-        paths = list(venv.lib_path.glob('{}*.*-info'.format(name.replace('-', '_'))))
+        paths = list(venv.lib_path.glob('{}-*.*-info'.format(name_anycase.replace('-', '_'))))
         if not paths:
             logger.critical('cannot locate dist-info for installed package')
             return None


### PR DESCRIPTION
The search for the right *-info directory has two problems:

1. It is not case-insensitive, and Sphinx generates a
   "Sphinx-2.3.1.dist-info" directory.

2. It is not selective to the specific package name, Sphinx
   also installs several "sphinxcontrib" packages which interfere.

A probably much better way would be to use
https://importlib-metadata.readthedocs.io/en/latest/using.html#entry-points