### PR TITLE
Fix sampleproject example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Let's get [sampleproject](https://github.com/pypa/sampleproject) and make it bet
 
 ```bash
 git clone https://github.com/pypa/sampleproject.git
+git checkout f31ab988d6b8151ab45079b4d962761d9f4d4b2b
 cd sampleproject
 ```
 


### PR DESCRIPTION
- Before this change, the instructions with [github.com/sampleproject](https://github.com/pypa/sampleproject/commits/master) would fail during the `dephell deps convert --from=setup.py --to=pyproject.toml` step with the error:

> WARNING cannot find tool.dephell section in the config (path=pyproject.toml)
ERROR NonExistentKey: 'Key "build-system" does not exist.' 

This is because the `HEAD` of `sampleproject`'s master branch now includes a pyproject file with a section that causes the error above.

- After this change, the sample project example works again because an instruction is added to checkout a commit hash from ~Nov 2019 where pyproject hadn't been added to the `sampleproject` repo yet.