### PR TITLE
Remove flatdict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ bowler = {optional = true, version = "*"}
 docker = {optional = true, version = "*"}
 dockerpty = {optional = true, version = "*"}
 fissix = {optional = true, allows-prereleases = true, version = "*"}
-flatdict = {optional = true, version = "*"}
 graphviz = {optional = true, version = "*"}
 html5lib = {optional = true, version = "*"}
 pygments = {optional = true, version = "*"}
@@ -198,4 +197,4 @@ isort = {extras = ["pyproject"], version = "*"}
 [tool.poetry.extras]
 docs = ["alabaster", "pygments-github-lexers", "recommonmark", "sphinx"]
 tests = ["aioresponses", "pytest", "requests-mock"]
-full = ["aiofiles", "appdirs", "autopep8", "bowler", "colorama", "docker", "dockerpty", "fissix", "flatdict", "graphviz", "html5lib", "pygments", "ruamel-yaml", "tabulate", "yapf"]
+full = ["aiofiles", "appdirs", "autopep8", "bowler", "colorama", "docker", "dockerpty", "fissix", "graphviz", "html5lib", "pygments", "ruamel-yaml", "tabulate", "yapf"]

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         ],
         "full": [
             "aiofiles", "appdirs", "autopep8", "bowler", "colorama", "docker",
-            "dockerpty", "fissix", "flatdict", "graphviz", "html5lib",
+            "dockerpty", "fissix", "graphviz", "html5lib",
             "pygments", "tabulate", "yapf"
         ],
         "tests": ["aioresponses", "pytest", "requests-mock"]

--- a/tests/test_actions/test_json.py
+++ b/tests/test_actions/test_json.py
@@ -1,0 +1,15 @@
+import pytest
+
+from dephell.actions._json import _flatdict
+
+
+@pytest.mark.parametrize('given, expected', [
+    (1, 1),
+    ({1: 2}, {'1': 2}),
+    ({1: {2: 3}}, {'1.2': 3}),
+    ({1: {2: 3, 4: 5}}, {'1.2': 3, '1.4': 5}),
+    ({1: {2: 3, 4: 5}, 6: 7}, {'1.2': 3, '1.4': 5, '6': 7}),
+    ([{1: {2: 3}}, {4: {5: 6}}], [{'1.2': 3}, {'4.5': 6}]),
+])
+def test_flatdict(given, expected):
+    assert _flatdict(given) == expected


### PR DESCRIPTION
I should be more selective about dependencies contributed into dephell. Flatdict is a library that I had a lot of headaches with. Now all CIs are broken because of it. And it can be replaced by one small function. Here it goes.