### PR TITLE
`dephell project bump` improvements

### DIFF
--- a/dephell/commands/project_bump.py
+++ b/dephell/commands/project_bump.py
@@ -17,11 +17,18 @@ from .base import BaseCommand
 
 
 FILE_NAMES = (
+    # dunder
     '__init__.py',
     '__version__.py',
     '__about__.py',
+
+    # sunder
     '_version.py',
     '_about.py',
+
+    # human
+    'version.py',
+    'about.py',
 )
 
 

--- a/dephell/converters/poetry.py
+++ b/dephell/converters/poetry.py
@@ -223,6 +223,8 @@ class PoetryConverter(BaseConverter):
                 section['extras'] = tomlkit.table()
             # add new extras
             for extra, deps in extras.items():
+                if list(section['extras'].get(extra, [])) == deps:
+                    continue
                 section['extras'][extra] = deps
         elif 'extras' in section:
             # deop all old extras if there are no new extras

--- a/docs/cmd-project-bump.md
+++ b/docs/cmd-project-bump.md
@@ -15,6 +15,19 @@ It's recommend to explicitly add `versioning` in config to let your users know w
 versioning = "semver"
 ```
 
+If you don't have [dephell config](config), you should explicitly specify `from` parameter:
+
+```bash
+dephell project bump --from-format=poetry --from-path=pyproject.toml minor
+```
+
+Or just add it into your config:
+
+```toml
+[tool.dephell.main]
+from = {format = "poetry", path = "pyproject.toml"}
+```
+
 Command steps:
 
 1. Try to detect version from `from` file.
@@ -23,7 +36,9 @@ Command steps:
 1. Write new version in source code. DepHell looks for `__version__` variable in project source and writes new version in it.
 1. Write new version in `from` file.
 
-Also, the command adds git tag if `--tag` option (or `tag = <your_template>` in the config) is specified as template.
+## Git tag
+
+The command adds git tag if `--tag` option (or `tag = <your_template>` in the config) is specified as template.
 Template can be string with `{version}` placeholder (e.g. `v.{version}`) or just prefix string (e.g. `v.`)
 
 ```bash

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,8 +33,8 @@ project = 'DepHell'
 copyright = '{}, Gram (@orsinium)'.format(date.today().year)
 author = 'Gram (@orsinium)'
 
-version = '0.7'
-release = '0.7.0'
+version = '0.8.1'
+release = version
 
 language = None
 exclude_patterns = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,6 @@ docs = ["alabaster", "pygments-github-lexers", "recommonmark", "sphinx"]
 tests = ["aioresponses", "pytest", "requests-mock"]
 full = [
     "aiofiles", "appdirs", "autopep8", "bowler", "colorama", "docker",
-    "dockerpty", "fissix", "graphviz", "html5lib", "python-gnupg", "pygments",
+    "dockerpty", "fissix", "graphviz", "html5lib", "pygments", "python-gnupg",
     "ruamel-yaml", "tabulate", "yapf",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ to = {format = "setuppy", path = "setup.py"}
 
 # explicitly specify your versioning scheme to let your users know what they can expect
 versioning = "semver"
+# git tag template for releases
+tag = "v."
 
 # Make lockfile
 # $ dephell deps convert --env=lock


### PR DESCRIPTION
1. Bump `version.py`. Close #388
1. Improve docs a bit. Also related to #388.
1. Make `ruamel.yaml` fairly optional. See https://github.com/dephell/dephell/issues/402#issuecomment-599583535
1. Do not mess up extras in poetry if nothing has changed.
1. Bump version in `conf.py`. Close #373. @maksbotan did you have a request for this as well? :)