### PR TITLE
Ignore implicit config in `dephell jail`

### DIFF
--- a/dephell/actions/_json.py
+++ b/dephell/actions/_json.py
@@ -118,7 +118,7 @@ def _beautify(data, *, colors: bool, table: bool) -> str:
         # one dict
         if isinstance(data, dict):
             return tabulate.tabulate(
-                _flatdict(data).items(),
+                sorted(_flatdict(data).items()),
                 headers=('key', 'value'),
                 tablefmt='fancy_grid',
             )

--- a/dephell/commands/base.py
+++ b/dephell/commands/base.py
@@ -25,6 +25,7 @@ REX_WORD = re.compile(r'([a-z\d])([A-Z])')
 class BaseCommand(CommandHandler):
     logger = getLogger('dephell.commands')
     prog = 'dephell'
+    find_config = True
 
     @cached_property
     def config(self) -> Config:
@@ -78,6 +79,11 @@ class BaseCommand(CommandHandler):
         if path:
             config.attach_file(path=path, env=env)
             return True
+
+        # do not implicitly attach file for some commands like `jail`
+        if not cls.find_config:
+            cls.logger.debug('cannot find config file')
+            return False
 
         # if path isn't specified, carefully try default names
         for path in CONFIG_NAMES:

--- a/dephell/commands/generate_authors.py
+++ b/dephell/commands/generate_authors.py
@@ -11,6 +11,9 @@ from .base import BaseCommand
 class GenerateAuthorsCommand(BaseCommand):
     """Create AUTHORS file for project by git log.
     """
+    # because we don't actually use anything from the config
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/generate_contributing.py
+++ b/dephell/commands/generate_contributing.py
@@ -14,6 +14,8 @@ from .base import BaseCommand
 class GenerateContributingCommand(BaseCommand):
     """Create CONTRIBUTING.md for DepHell-based project.
     """
+    # because we don't actually use anything from the config
+    find_config = False
     file_name = 'CONTRIBUTING.md'
 
     @staticmethod

--- a/dephell/commands/generate_editorconfig.py
+++ b/dephell/commands/generate_editorconfig.py
@@ -12,6 +12,9 @@ class GenerateEditorconfigCommand(BaseCommand):
     """Create EditorConfig for project.
     https://editorconfig.org/
     """
+    # because we don't actually use anything from the config
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/generate_travis.py
+++ b/dephell/commands/generate_travis.py
@@ -13,9 +13,13 @@ from .base import BaseCommand
 
 class GenerateTravisCommand(BaseCommand):
     """Create .travis.yml for DepHell-based project.
+
     https://docs.travis-ci.com/user/languages/python/
     https://docs.travis-ci.com/user/customizing-the-build
     """
+    # because we don't actually use anything from the config
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/inspect_gadget.py
+++ b/dephell/commands/inspect_gadget.py
@@ -47,6 +47,9 @@ class InspectGadgetCommand(BaseCommand):
 
     This command shouldn't be documented.
     """
+    # because we don't actually use anything from the config
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/jail_install.py
+++ b/dephell/commands/jail_install.py
@@ -16,6 +16,8 @@ from .base import BaseCommand
 class JailInstallCommand(BaseCommand):
     """Download and install package into isolated environment.
     """
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/jail_list.py
+++ b/dephell/commands/jail_list.py
@@ -12,6 +12,8 @@ from .base import BaseCommand
 class JailListCommand(BaseCommand):
     """Show all jails and their entrypoints.
     """
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/jail_remove.py
+++ b/dephell/commands/jail_remove.py
@@ -15,6 +15,8 @@ from .base import BaseCommand
 class JailRemoveCommand(BaseCommand):
     """Remove package isolated environment.
     """
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/jail_show.py
+++ b/dephell/commands/jail_show.py
@@ -16,6 +16,8 @@ from .base import BaseCommand
 class JailShowCommand(BaseCommand):
     """Show info about the package isolated environment.
     """
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/jail_try.py
+++ b/dephell/commands/jail_try.py
@@ -19,6 +19,8 @@ from .base import BaseCommand
 class JailTryCommand(BaseCommand):
     """Try packages into temporary isolated environment.
     """
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/package_bug.py
+++ b/dephell/commands/package_bug.py
@@ -16,6 +16,8 @@ from .base import BaseCommand
 class PackageBugCommand(BaseCommand):
     """Report bug in a package.
     """
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/package_changelog.py
+++ b/dephell/commands/package_changelog.py
@@ -17,6 +17,9 @@ DEFAULT_WIDTH = int(os.environ.get('COLUMNS', 90))
 class PackageChangelogCommand(BaseCommand):
     """Find project changelog.
     """
+    # because we don't actually use anything from the config
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/self_auth.py
+++ b/dephell/commands/self_auth.py
@@ -13,6 +13,8 @@ from .base import BaseCommand
 class SelfAuthCommand(BaseCommand):
     """Insert, update or delete credentials.
     """
+    # because we don't actually use anything from the config
+    find_config = False
     _global_config_path = get_data_dir() / GLOBAL_CONFIG_NAME
 
     @staticmethod

--- a/dephell/commands/self_autocomplete.py
+++ b/dephell/commands/self_autocomplete.py
@@ -16,6 +16,8 @@ from .base import BaseCommand
 class SelfAutocompleteCommand(BaseCommand):
     """Enable DepHell commands autocomplete for current shell.
     """
+    # because we don't actually use anything from the config
+    find_config = False
 
     @staticmethod
     def build_parser(parser) -> ArgumentParser:

--- a/dephell/commands/self_uncache.py
+++ b/dephell/commands/self_uncache.py
@@ -12,6 +12,9 @@ from .base import BaseCommand
 class SelfUncacheCommand(BaseCommand):
     """Remove dephell cache.
     """
+    # because we don't actually use anything from the config
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)

--- a/dephell/commands/self_upgrade.py
+++ b/dephell/commands/self_upgrade.py
@@ -14,6 +14,9 @@ from .base import BaseCommand
 class SelfUpgradeCommand(BaseCommand):
     """Upgrade DepHell to the latest version.
     """
+    # because we don't actually use anything from the config
+    find_config = False
+
     @staticmethod
     def build_parser(parser) -> ArgumentParser:
         builders.build_config(parser)
@@ -27,13 +30,15 @@ class SelfUpgradeCommand(BaseCommand):
             return self._upgrade_repo(path=path)
         return self._upgrade_package()
 
-    def _upgrade_repo(self, path: Path) -> bool:
+    @staticmethod
+    def _upgrade_repo(path: Path) -> bool:
         with chdir(path):
             cmd = ['git', 'pull', 'origin', 'master']
             result = subprocess.run(cmd)
             return (result.returncode == 0)
 
-    def _upgrade_package(self) -> bool:
+    @staticmethod
+    def _upgrade_package() -> bool:
         manager = PackageManager(executable=Path(sys.executable))
         args = ['-U']
         if manager.is_global:

--- a/docs/cmd-jail-show.md
+++ b/docs/cmd-jail-show.md
@@ -1,4 +1,4 @@
-# dephell jail list
+# dephell jail show
 
 Shows information about a jail installed by [dephell jail install](cmd-jail-install).
 


### PR DESCRIPTION
1. Globall config is used
1. CLI options are used
1. Explicitly specified config is used
1. CHANGED: Implicitly found config is not used for `jail` anymore.

I guess that's what you expect ;)

UPD: do the same for more commands where config isn't actually used. It helps to avoid warning about missed config.

Close #375 