### PR TITLE
Simplify links putting for old formats

### DIFF
--- a/dephell/constants.py
+++ b/dephell/constants.py
@@ -27,6 +27,9 @@ WAREHOUSE_DOMAINS = {'pypi.org', 'pypi.python.org', 'test.pypi.org'}
 DEFAULT_UPLOAD = 'https://upload.pypi.org/legacy/'
 TEST_UPLOAD = 'https://test.pypi.org/legacy/'
 
+HOMEPAGE_FIELD = 'homepage'
+DOWNLOAD_FIELD = 'download'
+
 FORMATS = (
     'conda',
     'egginfo',

--- a/dephell/controllers/_uploader.py
+++ b/dephell/controllers/_uploader.py
@@ -135,17 +135,9 @@ class Uploader:
             if author.mail:
                 meta['maintainer_email'] = author.mail
 
-        fields = dict(
-            homepage='home_page',
-            home='home_page',
-            download='download_url',
-        )
         for key, url in root.links.items():
-            if key in fields:
-                meta[fields[key]] = url
-            else:
-                key = key[0].upper() + key[1:]
-                meta['project_urls'].append('{}, {}'.format(key, url))
+            key = key[0].upper() + key[1:]
+            meta['project_urls'].append('{}, {}'.format(key, url))
 
         if root.python:
             meta['requires_python'] = str(root.python.peppify())

--- a/dephell/converters/egginfo.py
+++ b/dephell/converters/egginfo.py
@@ -138,7 +138,7 @@ class _Reader:
                 root.links[key] = link
         for link in cls._get_list(info, 'Project-URL'):
             key, url = link.split(', ')
-            root.links[key] = url
+            root.links[key.lower()] = url
 
         # authors
         for name in ('author', 'maintainer'):

--- a/dephell/converters/egginfo.py
+++ b/dephell/converters/egginfo.py
@@ -12,7 +12,7 @@ from dephell_markers import Markers
 from packaging.requirements import Requirement as PackagingRequirement
 
 # app
-from ..constants import HOMEPAGE_FIELD, DOWNLOAD_FIELD
+from ..constants import DOWNLOAD_FIELD, HOMEPAGE_FIELD
 from ..controllers import DependencyMaker, Readme
 from ..models import Author, EntryPoint, RootDependency
 from .base import BaseConverter

--- a/dephell/converters/egginfo.py
+++ b/dephell/converters/egginfo.py
@@ -12,6 +12,7 @@ from dephell_markers import Markers
 from packaging.requirements import Requirement as PackagingRequirement
 
 # app
+from ..constants import HOMEPAGE_FIELD, DOWNLOAD_FIELD
 from ..controllers import DependencyMaker, Readme
 from ..models import Author, EntryPoint, RootDependency
 from .base import BaseConverter
@@ -128,8 +129,8 @@ class _Reader:
 
         # links
         fields = (
-            ('homepage', 'Home-Page'),
-            ('download', 'Download-URL'),
+            (HOMEPAGE_FIELD, 'Home-Page'),
+            (DOWNLOAD_FIELD, 'Download-URL'),
         )
         for key, name in fields:
             link = cls._get(info, name)
@@ -268,16 +269,9 @@ class _Writer:
             content.append(('Summary', project.description))
 
         # links
-        fields = dict(
-            homepage='Home-Page',
-            download='Download-URL',
-        )
         for key, url in project.links.items():
-            if key in fields:
-                content.append((fields[key], url))
-            else:
-                key = key[0].upper() + key[1:]
-                content.append(('Project-URL', '{}, {}'.format(key, url)))
+            key = key[0].upper() + key[1:]
+            content.append(('Project-URL', '{}, {}'.format(key, url)))
 
         # authors
         if project.authors:

--- a/dephell/converters/flit.py
+++ b/dephell/converters/flit.py
@@ -10,6 +10,7 @@ from dephell_specifier import RangeSpecifier
 from packaging.requirements import Requirement
 
 # app
+from ..constants import HOMEPAGE_FIELD
 from ..controllers import DependencyMaker, Readme
 from ..models import Author, EntryPoint, RootDependency
 from .base import BaseConverter
@@ -81,7 +82,7 @@ class FlitConverter(BaseConverter):
 
         # links
         if 'home-page' in section:
-            root.links['homepage'] = section['home-page']
+            root.links[HOMEPAGE_FIELD] = section['home-page']
         if 'urls' in section:
             root.links.update(section['urls'])
 
@@ -175,9 +176,7 @@ class FlitConverter(BaseConverter):
                 section[field] = value
 
         # write links
-        if 'homepage' in project.links:
-            section['home-page'] = project.links['homepage']
-        if set(project.links) - {'homepage'}:
+        if project.links:
             if 'urls' in section:
                 # remove old
                 for name in section['urls']:
@@ -187,8 +186,6 @@ class FlitConverter(BaseConverter):
                 section['urls'] = tomlkit.table()
             # add and update
             for name, url in project.links.items():
-                if name == 'homepage':
-                    continue
                 section['urls'][name] = url
         elif 'urls' in section:
             del section['urls']

--- a/dephell/converters/setuppy.py
+++ b/dephell/converters/setuppy.py
@@ -13,6 +13,7 @@ from dephell_specifier import RangeSpecifier
 from packaging.requirements import Requirement
 
 # app
+from ..constants import HOMEPAGE_FIELD, DOWNLOAD_FIELD
 from ..controllers import DependencyMaker, Readme
 from ..models import Author, EntryPoint, RootDependency
 from .base import BaseConverter
@@ -94,7 +95,11 @@ class SetupPyConverter(BaseConverter):
         )
 
         # links
-        for key, name in (('home', 'url'), ('download', 'download_url')):
+        fields = (
+            (HOMEPAGE_FIELD, 'url'),
+            (DOWNLOAD_FIELD, 'download_url'),
+        )
+        for key, name in fields:
             link = data.get(name)
             if link:
                 root.links[key] = link
@@ -158,13 +163,6 @@ class SetupPyConverter(BaseConverter):
             content.append(('python_requires', str(project.python.peppify())))
 
         # links
-        fields = (
-            ('home', 'url'),
-            ('download', 'download_url'),
-        )
-        for key, name in fields:
-            if key in project.links:
-                content.append((name, project.links[key]))
         if project.links:
             content.append(('project_urls', project.links))
 

--- a/dephell/converters/setuppy.py
+++ b/dephell/converters/setuppy.py
@@ -13,7 +13,7 @@ from dephell_specifier import RangeSpecifier
 from packaging.requirements import Requirement
 
 # app
-from ..constants import HOMEPAGE_FIELD, DOWNLOAD_FIELD
+from ..constants import DOWNLOAD_FIELD, HOMEPAGE_FIELD
 from ..controllers import DependencyMaker, Readme
 from ..models import Author, EntryPoint, RootDependency
 from .base import BaseConverter

--- a/dephell/repositories/_conda/_cloud.py
+++ b/dephell/repositories/_conda/_cloud.py
@@ -16,9 +16,9 @@ from packaging.version import parse
 
 # app
 from ...cache import JSONCache
-from ...constants import HOMEPAGE_FIELD
 from ...cached_property import cached_property
 from ...config import config
+from ...constants import HOMEPAGE_FIELD
 from ...models.release import Release
 from ...models.simple_dependency import SimpleDependency
 from ...networking import requests_session

--- a/dephell/repositories/_conda/_cloud.py
+++ b/dephell/repositories/_conda/_cloud.py
@@ -16,6 +16,7 @@ from packaging.version import parse
 
 # app
 from ...cache import JSONCache
+from ...constants import HOMEPAGE_FIELD
 from ...cached_property import cached_property
 from ...config import config
 from ...models.release import Release
@@ -34,7 +35,7 @@ from ._base import CondaBaseRepo
 # https://repo.anaconda.com/pkgs/r/noarch
 
 URL_FIELDS = {
-    'home': 'homepage',
+    'home': HOMEPAGE_FIELD,
     'dev_url': 'repository',
     'doc_url': 'documentation',
     'license_url': 'license',

--- a/dephell/repositories/_conda/_git.py
+++ b/dephell/repositories/_conda/_git.py
@@ -16,10 +16,10 @@ from dephell_specifier import RangeSpecifier
 from jinja2 import Environment
 
 # app
-from ...constants import HOMEPAGE_FIELD
 from ...cache import JSONCache
 from ...cached_property import cached_property
 from ...config import config
+from ...constants import HOMEPAGE_FIELD
 from ...models.release import Release
 from ...models.simple_dependency import SimpleDependency
 from ...networking import aiohttp_session, requests_session

--- a/dephell/repositories/_conda/_git.py
+++ b/dephell/repositories/_conda/_git.py
@@ -16,6 +16,7 @@ from dephell_specifier import RangeSpecifier
 from jinja2 import Environment
 
 # app
+from ...constants import HOMEPAGE_FIELD
 from ...cache import JSONCache
 from ...cached_property import cached_property
 from ...config import config
@@ -43,7 +44,7 @@ HISTORY_URL = 'https://api.github.com/repos/{repo}/commits?path={path}&per_page=
 CONTENT_URL = 'https://raw.githubusercontent.com/{repo}/{rev}/{path}'
 
 URL_FIELDS = {
-    'home': 'homepage',
+    'home': HOMEPAGE_FIELD,
     'dev_url': 'repository',
     'doc_url': 'documentation',
     'license_url': 'license',

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-# built-in
 import os.path
-
 
 readme = ''
 here = os.path.abspath(os.path.dirname(__file__))
@@ -78,7 +76,7 @@ setup(
         "full": [
             "aiofiles", "appdirs", "autopep8", "bowler", "colorama", "docker",
             "dockerpty", "fissix", "graphviz", "html5lib", "pygments",
-            "tabulate", "yapf"
+            "python-gnupg", "tabulate", "yapf"
         ],
         "tests": ["aioresponses", "pytest", "requests-mock"]
     },

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ try:
 except ImportError:
     from distutils.core import setup
 
+# built-in
 import os.path
+
 
 readme = ''
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tests/requirements/setup.py
+++ b/tests/requirements/setup.py
@@ -20,7 +20,6 @@ setup(
     description='Dependency resolution for Python',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://dephell.org/',
     author='orsinium',
 
     packages=[],
@@ -47,7 +46,8 @@ setup(
     ],
     keywords='sample setuptools development',
     project_urls={  # Optional
-        'Source': 'https://github.com/dephell/dephell/',
+        'homepage': 'https://dephell.org/',
+        'source': 'https://github.com/dephell/dephell/',
     },
     entry_points={
         'console_scripts': ['dephell = dephell.cli:entrypoint'],

--- a/tests/test_converters/test_egginfo.py
+++ b/tests/test_converters/test_egginfo.py
@@ -68,4 +68,5 @@ def test_dumps_metainfo(requirements_path: Path):
     parsed = Parser().parsestr(content)
     assert parsed.get('Name') == 'dephell'
     assert parsed.get('Version') == '0.2.0'
-    assert parsed.get('Home-Page') == 'https://github.com/orsinium/dephell'
+    exp = ['Homepage, https://github.com/orsinium/dephell']
+    assert parsed.get_all('Project-URL') == exp

--- a/tests/test_repositories/test_local.py
+++ b/tests/test_repositories/test_local.py
@@ -22,7 +22,7 @@ def test_root_dir(requirements_path: Path):
     root = repo.get_root(name='dephell', version='0.2.0')
     assert root.name == 'dephell'
     assert root.version == '0.2.1'
-    assert root.links['home'] == 'https://github.com/orsinium/dephell'
+    assert root.links['homepage'] == 'https://github.com/orsinium/dephell'
 
 
 def test_deps_file(requirements_path: Path):


### PR DESCRIPTION
For PyPI, passing `home_page` and having `Homepage` in `project_urls` is the same. So, let's stop putting `url` and `download_url` as separate fields and just use `project_urls` for everything. Easy to remember, easy to code.