### PR TITLE
Small fixes in requesting warehouse (simple and API)

### DIFF
--- a/dephell/cache.py
+++ b/dephell/cache.py
@@ -16,7 +16,7 @@ class BaseCache:
     def __init__(self, *keys, ttl: int = -1):
         self.path = Path(config['cache']['path'], *keys)
         if self.ext:
-            self.path = self.path.with_suffix(self.ext)
+            self.path = self.path.with_name(self.path.name + self.ext)
         self.ttl = ttl
         self._check_ttl()
 

--- a/dephell/commands/deps_tree.py
+++ b/dephell/commands/deps_tree.py
@@ -63,12 +63,18 @@ class DepsTreeCommand(BaseCommand):
 
     @classmethod
     def _make_tree(cls, dep, *, level: int = 0) -> List[str]:
-        lines = ['{level}- {name} [required: {constraint}, locked: {best}, latest: {latest}]'.format(
+        best = dep.group.best_release.version
+        latest = dep.group.best_release.version
+        if best == latest:
+            template = '{level}- {name} [required: {constraint}, latest: {latest}]'
+        else:
+            template = '{level}- {name} [required: {constraint}, locked: {best}, latest: {latest}]'
+        lines = [template.format(
             level='  ' * level,
             name=dep.name,
             constraint=str(dep.constraint) or '*',
-            best=str(dep.group.best_release.version),
-            latest=str(dep.groups.releases[0].version),
+            best=str(best),
+            latest=str(latest),
         )]
         deps = {dep.name: dep for dep in dep.dependencies}.values()  # drop duplicates
         for subdep in sorted(deps):

--- a/dephell/converters/egginfo.py
+++ b/dephell/converters/egginfo.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional
 from dephell_discover import Root as PackageRoot
 from dephell_links import parse_link
 from dephell_markers import Markers
-from packaging.requirements import Requirement as PackagingRequirement, InvalidRequirement
+from packaging.requirements import InvalidRequirement, Requirement as PackagingRequirement
 
 # app
 from ..constants import DOWNLOAD_FIELD, HOMEPAGE_FIELD

--- a/dephell/models/dependency.py
+++ b/dephell/models/dependency.py
@@ -193,7 +193,7 @@ class Dependency:
 
         marker = Markers(str(self.marker))
         if self.envs - {'main'}:
-            extra_markers = {'extra == "{}"'.format(env) for env in self.envs - {'main'}}
+            extra_markers = {'extra == {!r}'.format(env) for env in self.envs - {'main'}}
             marker &= Markers(' or '.join(extra_markers))
         if marker:
             result += '; ' + str(marker)

--- a/dephell/networking.py
+++ b/dephell/networking.py
@@ -7,7 +7,7 @@ from ssl import create_default_context
 # external
 import certifi
 import requests
-from aiohttp import ClientSession, TCPConnector, ClientPayloadError
+from aiohttp import ClientSession, TCPConnector, ClientError
 
 # app
 from . import __version__
@@ -50,7 +50,7 @@ def aiohttp_repeat(func=None, *, count: int = 4):
         for pause in range(1, count + 1):
             try:
                 return await func(*args, **kwargs)
-            except ClientPayloadError:
+            except ClientError:
                 if pause == count:
                     raise
                 logger.debug('aiohttp payload error, repeating...', exc_info=True)

--- a/dephell/networking.py
+++ b/dephell/networking.py
@@ -1,13 +1,13 @@
 # built-in
 from functools import partial, update_wrapper
 from logging import getLogger
-from time import sleep
 from ssl import create_default_context
+from time import sleep
 
 # external
 import certifi
 import requests
-from aiohttp import ClientSession, TCPConnector, ClientError
+from aiohttp import ClientError, ClientSession, TCPConnector
 
 # app
 from . import __version__

--- a/dephell/networking.py
+++ b/dephell/networking.py
@@ -42,7 +42,7 @@ def requests_session(*, auth=None, headers=None, **kwargs):
     return session
 
 
-def aiohttp_repeat(func=None, *, count: int = 3):
+def aiohttp_repeat(func=None, *, count: int = 4):
     if func is None:
         return partial(func, count=count)
 

--- a/dephell/repositories/_warehouse/_base.py
+++ b/dephell/repositories/_warehouse/_base.py
@@ -99,22 +99,23 @@ class WarehouseBaseRepo(Interface):
                     ))
 
             try:
-                dep_extra = req.marker and Markers(req.marker).extra
+                dep_extras = req.marker and Markers(req.marker).get_strings('extra')
             except ValueError:  # unsupported operation for version marker python_version: in
-                dep_extra = None
+                dep_extras = set()
 
             # it's not extra and we want not extra too
-            if dep_extra is None and extra is None:
+            if not dep_extras and extra is None:
                 result.append(req)
                 continue
             # it's extra, but we want not the extra
             # or it's not the extra, but we want extra.
-            if dep_extra is None or extra is None:
+            if not dep_extras or extra is None:
                 continue
             # it's extra and we want this extra
-            elif dep_extra == extra:
-                result.append(req)
-                continue
+            for dep_extra in dep_extras:
+                if dep_extra == extra:
+                    result.append(req)
+                    break
 
         return tuple(result)
 

--- a/dephell/repositories/_warehouse/_base.py
+++ b/dephell/repositories/_warehouse/_base.py
@@ -13,7 +13,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 # app
 from ...cached_property import cached_property
 from ...constants import WAREHOUSE_DOMAINS
-from ...networking import aiohttp_session, aiohttp_repeat
+from ...networking import aiohttp_repeat, aiohttp_session
 from ..base import Interface
 
 

--- a/dephell/repositories/_warehouse/_base.py
+++ b/dephell/repositories/_warehouse/_base.py
@@ -13,7 +13,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 # app
 from ...cached_property import cached_property
 from ...constants import WAREHOUSE_DOMAINS
-from ...networking import aiohttp_session
+from ...networking import aiohttp_session, aiohttp_repeat
 from ..base import Interface
 
 
@@ -136,6 +136,7 @@ class WarehouseBaseRepo(Interface):
                         deps.append(str(dep))
             return tuple(deps)
 
+    @aiohttp_repeat
     async def _download(self, *, url: str, path: Path) -> None:
         async with aiohttp_session(auth=self.auth) as session:
             async with session.get(url) as response:

--- a/dephell/repositories/_warehouse/_simple.py
+++ b/dephell/repositories/_warehouse/_simple.py
@@ -143,7 +143,8 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
         )
         links = cache.load()
         if links:
-            return links
+            yield from links
+            return
 
         dep_url = posixpath.join(self.url, quote(name)) + '/'
         with requests_session() as session:

--- a/dephell/repositories/_warehouse/_simple.py
+++ b/dephell/repositories/_warehouse/_simple.py
@@ -211,9 +211,6 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
             (sdist, '.zip'),
         )
 
-        if name == 'celery':
-            import pdb; pdb.set_trace()
-
         for converter, ext in rules:
             for link in good_links:
                 if not link['name'].endswith(ext):

--- a/dephell/repositories/_warehouse/_simple.py
+++ b/dephell/repositories/_warehouse/_simple.py
@@ -53,9 +53,19 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
         releases_info = dict()
         for link in links:
             name, version = self._parse_name(link['name'])
-            if canonicalize_name(name) != dep.name:
+            if canonicalize_name(name) != canonicalize_name(dep.base_name):
+                logger.warning('bad dist name', extra=dict(
+                    dist_name=link['name'],
+                    package_name=dep.base_name,
+                    reason='package name does not match',
+                ))
                 continue
             if not version:
+                logger.warning('bad dist name', extra=dict(
+                    dist_name=link['name'],
+                    package_name=dep.base_name,
+                    reason='no version specified',
+                ))
                 continue
 
             if version not in releases_info:

--- a/dephell/repositories/_warehouse/_simple.py
+++ b/dephell/repositories/_warehouse/_simple.py
@@ -147,6 +147,7 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
 
         dep_url = posixpath.join(self.url, quote(name)) + '/'
         with requests_session() as session:
+            logger.debug('getting dep info from simple repo', extra=dict(url=dep_url))
             response = session.get(dep_url, auth=self.auth)
         if response.status_code == 404:
             raise PackageNotFoundError(package=name, url=dep_url)
@@ -164,12 +165,14 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
 
             python = tag.get('data-requires-python')
             fragment = parse_qs(parsed.fragment)
-            yield dict(
+            link = dict(
                 url=urljoin(dep_url, link),
                 name=parsed.path.strip('/').split('/')[-1],
                 python=html.unescape(python) if python else '*',
                 digest=fragment['sha256'][0] if 'sha256' in fragment else None,
             )
+            links.append(link)
+            yield link
 
         cache.dump(links)
         return links

--- a/dephell/repositories/_warehouse/_simple.py
+++ b/dephell/repositories/_warehouse/_simple.py
@@ -152,7 +152,7 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
             ttl=config['cache']['ttl'],
         )
         links = cache.load()
-        if links:
+        if links is not None:
             yield from links
             return
 

--- a/dephell/repositories/_warehouse/_simple.py
+++ b/dephell/repositories/_warehouse/_simple.py
@@ -188,7 +188,7 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
         cache.dump(links)
         return links
 
-    async def _get_deps_from_links(self, name, version):
+    async def _get_deps_from_links(self, name: str, version):
         from ...converters import SDistConverter, WheelConverter
 
         links = self._get_links(name=name)
@@ -197,7 +197,7 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
             link_name, link_version = self._parse_name(link['name'])
             if canonicalize_name(link_name) != name:
                 continue
-            if link_version != version:
+            if link_version != str(version):
                 continue
             good_links.append(link)
 
@@ -210,6 +210,9 @@ class WarehouseSimpleRepo(WarehouseBaseRepo):
             (sdist, '.tar.gz'),
             (sdist, '.zip'),
         )
+
+        if name == 'celery':
+            import pdb; pdb.set_trace()
 
         for converter, ext in rules:
             for link in good_links:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 # external
 import alabaster
-from recommonmark.parser import CommonMarkParser
 from recommonmark.transform import AutoStructify
 
 
@@ -20,12 +19,10 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
+    'recommonmark',
 ]
 
 templates_path = ['_templates']
-source_parsers = {
-    '.md': CommonMarkParser,
-}
 source_suffix = ['.rst', '.md']
 master_doc = 'index'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,8 @@ exclude=
     .pytest_cache
     build
     setup.py
+
+[tool:pytest]
+addopts = --strict-markers
+markers =
+    allow_hosts: allow network requests to specified hostnames.

--- a/tests/test_controllers/test_safety.py
+++ b/tests/test_controllers/test_safety.py
@@ -9,5 +9,5 @@ from dephell.controllers import Safety
 def test_safety():
     safety = Safety()
     vulns = safety.get('django', '1.11.0')
-    assert len(vulns) == 5
+    assert len(vulns) == 13
     assert {vuln.name for vuln in vulns} == {'django'}


### PR DESCRIPTION
+ Fix cache name. Before it removed the last part of the version that resulted in the invalid cache.
+ Do not fail on broken archives on warehouse. Close #416
+ Simplify `deps tree` output to make it a bit more readable.
+ Do not fail on invalid extras.
+ Retry aiohttp network requests. Close #406 
+ Correctly parse dependencies with more than one extra for warehouse packages.
+ Fix caching for simple warehouse
+ Fix name and version matching for simple warehouse
