### PR TITLE
Fix wheel generation

### DIFF
--- a/dephell/commands/project_build.py
+++ b/dephell/commands/project_build.py
@@ -65,5 +65,5 @@ class ProjectBuildCommand(BaseCommand):
                 project=resolver.graph.metainfo,
             )
 
-        self.logger.info('builded')
+        self.logger.info('built')
         return True

--- a/dephell/converters/wheel.py
+++ b/dephell/converters/wheel.py
@@ -128,7 +128,9 @@ class _Writer:
                     for full_path in package:
                         self._write_file(
                             archive=archive,
-                            path='/'.join(full_path.relative_to(project.package.path).parts),
+                            path='/'.join(
+                                full_path.relative_to(project.package.path.joinpath(
+                                    project.package.package_dir[''])).parts),
                             fpath=full_path,
                         )
 


### PR DESCRIPTION
# Wheel Generation for Packages with src folder
Fixes issue #391 

## Problem
Packages containing a **src** folder above the package folder won't have a working wheel package when building the packages with `dephell build`

## Solution
Appending the found package dir to the project package path enables the converter to generate a working wheel package for packages with a **src** folder as well as for packages without one (when there is no **src** folder, this parameter contains the value `'.'` )

## Misc

Also fixed a typo in the *project_build* file.