### PR TITLE
Fix issue with not expanding home paths

### DIFF
--- a/dephell/config/builders.py
+++ b/dephell/config/builders.py
@@ -1,9 +1,17 @@
 # project
+# built-in
+from pathlib import Path
+
 # external
 from dephell_versioning import get_schemes
 
 # app
 from ..constants import FORMATS, LOG_FORMATTERS, LOG_LEVELS, REPOSITORIES, STRATEGIES
+
+
+# helper function for path values
+def expanded_path(string):
+    return Path(string).expanduser().resolve().as_posix()
 
 
 env_help = (
@@ -16,22 +24,22 @@ env_help = (
 
 def build_config(parser):
     config_group = parser.add_argument_group('Configuration file')
-    config_group.add_argument('-c', '--config', help='path to config file.')
+    config_group.add_argument('-c', '--config', help='path to config file.', type=expanded_path)
     config_group.add_argument('-e', '--env', help='environment in config.')
 
 
 def build_from(parser):
     from_group = parser.add_argument_group('Input file')
-    from_group.add_argument('--from', help='path or format for reading requirements.')
+    from_group.add_argument('--from', help='path or format for reading requirements.', type=expanded_path)
     from_group.add_argument('--from-format', choices=FORMATS, help='format for reading requirements.')
-    from_group.add_argument('--from-path', help='path to input file.')
+    from_group.add_argument('--from-path', help='path to input file.', type=expanded_path)
 
 
 def build_to(parser):
     to_group = parser.add_argument_group('Output file')
-    to_group.add_argument('--to', help='path or format for writing requirements.')
+    to_group.add_argument('--to', help='path or format for writing requirements.', type=expanded_path)
     to_group.add_argument('--to-format', choices=FORMATS, help='output requirements file format.')
-    to_group.add_argument('--to-path', help='path to output file.')
+    to_group.add_argument('--to-path', help='path to output file.', type=expanded_path)
     to_group.add_argument(
         '--sdist-ratio',
         help='ratio of tests and project size after which tests will be excluded from sdist.',
@@ -68,9 +76,9 @@ def build_output(parser):
 
 def build_venv(parser):
     venv_group = parser.add_argument_group('Virtual environment')
-    venv_group.add_argument('--venv', help='path to venv directory for project.')
+    venv_group.add_argument('--venv', help='path to venv directory for project.', type=expanded_path)
     venv_group.add_argument('--python', help='python version for venv.')
-    venv_group.add_argument('--dotenv', help='path to .env file')
+    venv_group.add_argument('--dotenv', help='path to .env file', type=expanded_path)
 
 
 def build_docker(parser):
@@ -83,14 +91,14 @@ def build_docker(parser):
 def build_other(parser):
     other_group = parser.add_argument_group('Other')
 
-    other_group.add_argument('--cache-path', help='path to dephell cache')
+    other_group.add_argument('--cache-path', help='path to dephell cache', type=expanded_path)
     other_group.add_argument('--cache-ttl', type=int, help='Time to live for releases list cache')
 
-    other_group.add_argument('--project', help='path to the current project')
-    other_group.add_argument('--bin', help='path to the dir for installing scripts')
-    other_group.add_argument('--ca', help='path to CA_BUNDLE file for SSL verification.')
+    other_group.add_argument('--project', help='path to the current project', type=expanded_path)
+    other_group.add_argument('--bin', help='path to the dir for installing scripts', type=expanded_path)
+    other_group.add_argument('--ca', help='path to CA_BUNDLE file for SSL verification.', type=expanded_path)
 
     other_group.add_argument('--envs', nargs='*', help='environments (main, dev) or extras to install')
-    other_group.add_argument('--tests', nargs='*', help='paths to test files')
+    other_group.add_argument('--tests', nargs='*', help='paths to test files', type=expanded_path)
     other_group.add_argument('--versioning', choices=sorted(get_schemes()),
                              help='versioning scheme for project')


### PR DESCRIPTION
# Fix expanding ~ (`$HOME`) in file path
Fixes issue #237 

## Problem
When using a path with the `$HOME` parameter `~`, this won't get expanded and will reference to the current directory.

## Solution
Update the config builder with an additional script to expand the user path for all received filepaths.