### PR TITLE
Safely test for optional "type" field in poetry lock

### DIFF
--- a/dephell/converters/poetrylock.py
+++ b/dephell/converters/poetrylock.py
@@ -118,12 +118,12 @@ class PoetryLockConverter(BaseConverter):
         # get link
         url = None
         if 'source' in content:
-            if content['source']['type'] == 'legacy':
+            if content['source'].get('type') == 'legacy':
                 repo = repo.make(content['source']['reference'])
             else:
                 repo = None
                 url = content['source']['url']
-                if content['source']['type'] == 'git':
+                if content['source'].get('type') == 'git':
                     url = 'git+' + url
                     if 'reference' in content['source']:
                         url += '@' + content['source']['reference']


### PR DESCRIPTION
The "source" field in a poetry lock file can optionally have a "type"
field. However, in cases where an alternative "simple" index is offered,
e.g., artifactory, this type field is not used. This patch makes
checking this type field safe by returning a None in the case that the
field doesn't exist.

Fixes: https://github.com/dephell/dephell/issues/437