### PR TITLE
Fix markers merging

### DIFF
--- a/dephell/models/marker_tracker.py
+++ b/dephell/models/marker_tracker.py
@@ -1,30 +1,42 @@
+from typing import Dict, Union
+
 # external
 from dephell_markers import Markers, OrMarker
 
 
 class MarkerTracker:
+    _markers: Dict[str, Markers]
+
     def __init__(self) -> None:
         self._markers = dict()
 
     @property
     def markers(self) -> Markers:
+        container = Markers()
+
+        if not self._markers:
+            return container
         if len(self._markers) == 1:
             return next(iter(self._markers.values()))
-        container = Markers()
-        markers = [m._marker for m in self._markers.values() if m._marker]
+
+        # Empty marker means "no markers should be applied, always match the dependency".
+        for marker in self._markers.values():
+            if not marker:
+                return container
+
+        # If no empty markers specified, merge all markers as `or`
+        markers = [m._marker for m in self._markers.values()]
         container._marker = OrMarker(*markers)
         return container
 
-    def apply(self, *, source, markers) -> 'MarkerTracker':
-        if not markers:
-            return self
+    def apply(self, *, source, markers: Union[str, Markers]) -> 'MarkerTracker':
         if type(source) is not str:
             source = source.name
         if source in self._markers:
             raise ValueError('marker for given source already added')
         if type(markers) is str:
             markers = Markers(markers)
-        self._markers[source] = markers
+        self._markers[source] = markers  # type: ignore
         return self
 
     def merge(self, other: 'MarkerTracker') -> None:
@@ -37,17 +49,17 @@ class MarkerTracker:
         if source in self._markers:
             del self._markers[source]
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         if name not in dir(Markers):
             raise AttributeError(name)
         return getattr(self.markers, name)
 
     def __bool__(self) -> bool:
-        return any(marker for marker in self._markers.values())
+        return bool(self.markers)
 
     def __str__(self) -> str:
         return str(self.markers)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         markers = map(repr, self._markers.values())
         return '{}({})'.format(type(self).__name__, ', '.join(markers))


### PR DESCRIPTION
When we merge markers for dependency from different sources and one 
source has an empty marker specified, convert it to empty markers after 
all. In other words, if a library has a dependency without markers 
specified that means "always install the dependency, no markers should 
be applied"