### PR TITLE
Add docs and assets to source tarball

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,11 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+include = [
+    "docs/*.md",
+    "assets/*.png",
+    "assets/*.svg"
+]
 
 [tool.poetry.scripts]
 dephell = "dephell.cli:entrypoint"


### PR DESCRIPTION
The docs are required to run the tests successfully
(test_params_all_described requires docs/params.md)