### PR TITLE
add install path option

### DIFF
--- a/install.py
+++ b/install.py
@@ -63,6 +63,7 @@ class Context:
     @cached_property
     def parser(self):
         parser = ArgumentParser()
+        parser.add_argument('--path', help='install dephell to a specific path')
         parser.add_argument('--branch', help='install dephell from git from given branch')
         parser.add_argument('--version', help='install specified version')
         parser.add_argument('--slug', default='dephell/dephell',
@@ -96,6 +97,8 @@ class Context:
 
     @cached_property
     def data_dir(self) -> Path:
+        if self.args.path:
+            return Path(self.args.path)
         try:
             from appdirs import user_data_dir
         except ImportError:


### PR DESCRIPTION
This PR provides an installation option `--path` which enables the user to specify the path (data_dir) in which dephell will be installed.

The use case for this option is to allow dephell to be managed by `asdf`. To enable this we must be able to specify the installation version and installation path.

I have a working asdf plugin [here](https://github.com/crflynn/asdf-dephell) which currently points to this branch in my fork. It would be ideal if it pointed to the actual dephell repository.