### PR TITLE
pin isort below 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ recommonmark = "*"
 pygments-github-lexers = "*"
 
 flake8-isort = "*"
-isort = {extras = ["pyproject"], version = "*"}
+isort = {extras = ["pyproject"], version = "<5"}
 # pre-commit = "*"
 
 [tool.poetry.extras]


### PR DESCRIPTION
flake8-isort is currently failing in travis due to this issue: https://github.com/gforcada/flake8-isort/issues/88
This pins isort below 5.0, which has breaking changes causing travis to fail.