### PR TITLE
Don't attempt to make relative paths relative

### DIFF
--- a/dephell/converters/base.py
+++ b/dephell/converters/base.py
@@ -122,6 +122,8 @@ class BaseConverter:
         return self._make_path_absolute(root=root, path=path)
 
     def _make_dependency_path_relative(self, path: Path) -> Path:
+        if not path.is_absolute():
+            return path
         root = self.resolve_path or self._resolve_path or self.project_path or Path()
         root = root.resolve()
         return path.relative_to(str(root))


### PR DESCRIPTION
I ran into this issue when having a develop (editable) package in my `pyproject.toml` Poetry section:

```
[tool.poetry.dependencies]
mypackage = {path = "lib/mypackage", develop = true}
```

This ends up in `poetry.lock` as:

```
[package.source]
reference = ""
type = "directory"
url = "lib/mypackage"
```

When trying to convert it into a `requirements.txt` it raises an error:

```
ValueError: 'lib/mypackage' does not start with '/Users/marcel/Workspace/someproject'
```

There's no issue when converting `poetry` to `pip`. This only happens when converting `poetrylock` to `pip`.